### PR TITLE
chore(ci): Pin nextest version on unix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,7 +66,7 @@ jobs:
     - name: Install cargo-nextest
       uses: taiki-e/install-action@v2
       with:
-        tool: nextest
+        tool: nextest@0.9.80
 
     - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.7


### PR DESCRIPTION
## Description

Some recent nextest version broke things.  We should probably debug
that but for now just pin nextest.

## Breaking Changes


## Notes & open questions


## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.