### PR TITLE
feat(netwatch): Allow newer `quinn-udp` versions

### DIFF
--- a/netwatch/Cargo.toml
+++ b/netwatch/Cargo.toml
@@ -25,7 +25,7 @@ futures-util = "0.3"
 libc = "0.2.139"
 netdev = "0.31.0"
 once_cell = "1.18.0"
-quinn-udp = { package = "iroh-quinn-udp", version = "0.5.5" }
+quinn-udp = { package = "iroh-quinn-udp", version = "0.5" }
 socket2 = "0.5.3"
 thiserror = "2"
 time = "0.3.20"


### PR DESCRIPTION
## Description

Updates the version bound from `0.5.5` to `0.5`, allowing newer non-breaking versions.

This allows me to update the iroh-quinn-udp version in `iroh`, making it possible to ship browser features.

## Breaking Changes

This is not a breaking change.

## Change checklist

- [x] Self-review.
- [x] All breaking changes documented.