### PR TITLE
fix: remove Netlink error variant for Android

### DIFF
--- a/netwatch/src/interfaces/linux.rs
+++ b/netwatch/src/interfaces/linux.rs
@@ -25,6 +25,7 @@ pub enum Error {
     MissingDestinationField,
     #[error("mask field is missing")]
     MissingMaskField,
+    #[cfg(not(target_os = "android"))]
     #[error("netlink")]
     Netlink(#[from] rtnetlink::Error),
 }


### PR DESCRIPTION
This fixes compilation of Delta Chat
in debug mode
for Android 5 (API level 21) using NDK 27.
Without this change symbols like
`process_vm_writev` which are not
actually used are pulled in
and break linking step.
They are only optimized out
in release mode.

See <https://github.com/chatmail/core/pull/6687>
for details.