### PR TITLE
fix(netwatch): Update `web-sys` version bound to `0.3.70`, the required version

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -20,4 +20,6 @@ expression = "MIT AND ISC AND OpenSSL"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 [advisories]
-ignore = []
+ignore = [
+    "RUSTSEC-2024-0436", # paste unmaintained
+]

--- a/netwatch/Cargo.toml
+++ b/netwatch/Cargo.toml
@@ -70,7 +70,7 @@ derive_more = { version = "1.0.0", features = ["debug"] }
 
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["EventListener", "EventTarget"] }
+web-sys = { version = "0.3.70", features = ["EventListener", "EventTarget"] }
 
 [dev-dependencies]
 testresult = "0.4.1"


### PR DESCRIPTION
## Description

Updates the web-sys version bound to `0.3.70`, the first web-sys version that this crate successfully builds with.

## Notes & open questions

Closes https://github.com/n0-computer/iroh/issues/3252

## Change checklist
- [x] Self-review.
