### PR TITLE
refactor(portmapper)!: non-global metrics collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,12 +266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,11 +932,10 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh-metrics"
 version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d64b607e49f67fa42b3e780109cad0fa1fdb476b4a78d4cf8443499bbc1ad0a"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Fderive-metricsgroupset#f8a2a047fc9f4232e0920501150efddc11be7060"
 dependencies = [
  "iroh-metrics-derive",
- "prometheus-client",
+ "itoa",
  "serde",
  "thiserror 2.0.11",
  "tracing",
@@ -951,8 +944,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caaa484b5f192006b1cc39261712d65baf87342fc72a4acc1560355d1dc410d9"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Fderive-metricsgroupset#f8a2a047fc9f4232e0920501150efddc11be7060"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1007,16 +999,6 @@ name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
-
-[[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1375,29 +1357,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,29 +1463,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus-client"
-version = "0.22.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot",
- "prometheus-client-derive-encode",
-]
-
-[[package]]
-name = "prometheus-client-derive-encode"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,15 +1499,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
-dependencies = [
- "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -1686,12 +1613,6 @@ name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "send_wrapper"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor2#4f10df0b5b94a51c513ee214214984c1ec1142b0"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor2#7ddd198e69230b4716806e69eb141eef04affd1a"
 dependencies = [
  "iroh-metrics-derive",
  "prometheus-client",
@@ -950,7 +950,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor2#4f10df0b5b94a51c513ee214214984c1ec1142b0"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor2#7ddd198e69230b4716806e69eb141eef04affd1a"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor2#34dedbcff364e8f1dcfdf8e13abf863b3bae60db"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor2#4f10df0b5b94a51c513ee214214984c1ec1142b0"
 dependencies = [
  "iroh-metrics-derive",
  "prometheus-client",
@@ -950,7 +950,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor2#34dedbcff364e8f1dcfdf8e13abf863b3bae60db"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor2#4f10df0b5b94a51c513ee214214984c1ec1142b0"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,15 +278,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "erased-serde"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -947,13 +938,24 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor#b7f521f03734e890725a8b2c6a70055ef97cee0b"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor2#34dedbcff364e8f1dcfdf8e13abf863b3bae60db"
 dependencies = [
+ "iroh-metrics-derive",
  "prometheus-client",
  "serde",
- "struct_iterable",
  "thiserror 2.0.11",
  "tracing",
+]
+
+[[package]]
+name = "iroh-metrics-derive"
+version = "0.1.0"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor2#34dedbcff364e8f1dcfdf8e13abf863b3bae60db"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1831,35 +1833,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "struct_iterable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849a064c6470a650b72e41fa6c057879b68f804d113af92900f27574828e7712"
-dependencies = [
- "struct_iterable_derive",
- "struct_iterable_internal",
-]
-
-[[package]]
-name = "struct_iterable_derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb939ce88a43ea4e9d012f2f6b4cc789deb2db9d47bad697952a85d6978662c"
-dependencies = [
- "erased-serde",
- "proc-macro2",
- "quote",
- "struct_iterable_internal",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "struct_iterable_internal"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9426b2a0c03e6cc2ea8dbc0168dbbf943f88755e409fb91bcb8f6a268305f4a"
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor2#7ddd198e69230b4716806e69eb141eef04affd1a"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor#a1a6e1090892bde5c2d2c115afd03a409f12f6a3"
 dependencies = [
  "iroh-metrics-derive",
  "prometheus-client",
@@ -950,7 +950,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor2#7ddd198e69230b4716806e69eb141eef04affd1a"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor#a1a6e1090892bde5c2d2c115afd03a409f12f6a3"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,8 +937,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iroh-metrics"
-version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor#a1a6e1090892bde5c2d2c115afd03a409f12f6a3"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d64b607e49f67fa42b3e780109cad0fa1fdb476b4a78d4cf8443499bbc1ad0a"
 dependencies = [
  "iroh-metrics-derive",
  "prometheus-client",
@@ -950,7 +951,8 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor#a1a6e1090892bde5c2d2c115afd03a409f12f6a3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caaa484b5f192006b1cc39261712d65baf87342fc72a4acc1560355d1dc410d9"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,8 +953,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f7cd1ffe3b152a5f4f4c1880e01e07d96001f20e02cc143cb7842987c616b3"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Fmetric-sets#7edb7839128f79089e113e76ae045ce3a3370427"
 dependencies = [
  "erased_set",
  "prometheus-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor#04b9c4fca09b15856d00da4640cfa3d882f3c750"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor#b7f521f03734e890725a8b2c6a70055ef97cee0b"
 dependencies = [
  "prometheus-client",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,12 +287,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "erased_set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a02a5d186d7bf1cb21f1f95e1a9cfa5c1f2dcd803a47aad454423ceec13525c5"
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,9 +947,8 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Fmetric-sets#7edb7839128f79089e113e76ae045ce3a3370427"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor#83b0335857dcfe379ffbf4e854851f209ddeeb6c"
 dependencies = [
- "erased_set",
  "prometheus-client",
  "serde",
  "struct_iterable",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor#83b0335857dcfe379ffbf4e854851f209ddeeb6c"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor#edca9ebc27d6ef7ba10a99b340356e8ff1c197f5"
 dependencies = [
  "prometheus-client",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,8 +931,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iroh-metrics"
-version = "0.33.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=main#a589407937d851c5e9424431b86eee24e3dddd93"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f70466f14caff7420a14373676947e25e2917af6a5b1bec45825beb2bf1eb6a7"
 dependencies = [
  "iroh-metrics-derive",
  "itoa",
@@ -943,8 +944,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=main#a589407937d851c5e9424431b86eee24e3dddd93"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d12f5c45c4ed2436302a4e03cad9a0ad34b2962ad0c5791e1019c0ee30eeb09"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,19 +932,19 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh-metrics"
 version = "0.33.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Fderive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=main#a589407937d851c5e9424431b86eee24e3dddd93"
 dependencies = [
  "iroh-metrics-derive",
  "itoa",
  "serde",
- "thiserror 2.0.11",
+ "snafu",
  "tracing",
 ]
 
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Fderive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=main#a589407937d851c5e9424431b86eee24e3dddd93"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh-metrics"
 version = "0.32.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor#edca9ebc27d6ef7ba10a99b340356e8ff1c197f5"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Frefactor#04b9c4fca09b15856d00da4640cfa3d882f3c750"
 dependencies = [
  "prometheus-client",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 [[package]]
 name = "iroh-metrics"
 version = "0.33.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Fderive-metricsgroupset#f8a2a047fc9f4232e0920501150efddc11be7060"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Fderive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
 dependencies = [
  "iroh-metrics-derive",
  "itoa",
@@ -944,7 +944,7 @@ dependencies = [
 [[package]]
 name = "iroh-metrics-derive"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Fderive-metricsgroupset#f8a2a047fc9f4232e0920501150efddc11be7060"
+source = "git+https://github.com/n0-computer/iroh-metrics?branch=Frando%2Fderive-metricsgroupset#ff3c5270a5e5e6bd909e9cd0214d659f899f0073"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,4 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)"] }
 unused-async = "warn"
 
 [patch.crates-io]
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/metric-sets" }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/refactor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,4 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)"] }
 unused-async = "warn"
 
 [patch.crates-io]
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/refactor" }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/refactor2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,4 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)"] }
 unused-async = "warn"
 
 [patch.crates-io]
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/refactor2" }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/refactor" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)"] }
 
 [workspace.lints.clippy]
 unused-async = "warn"
+
+[patch.crates-io]
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/metric-sets" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,3 @@ unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)"] }
 
 [workspace.lints.clippy]
 unused-async = "warn"
-
-[patch.crates-io]
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/refactor" }

--- a/portmapper/Cargo.toml
+++ b/portmapper/Cargo.toml
@@ -22,7 +22,7 @@ derive_more = { version = "1.0.0", features = ["debug", "display", "from", "try_
 futures-lite = "2.5"
 futures-util = "0.3.25"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
-iroh-metrics = "0.34"
+iroh-metrics = { version = "0.34", default-features = false }
 libc = "0.2.139"
 nested_enum_utils = "0.2.0"
 netwatch = { version = "0.4.0", path = "../netwatch" }

--- a/portmapper/Cargo.toml
+++ b/portmapper/Cargo.toml
@@ -22,7 +22,7 @@ derive_more = { version = "1.0.0", features = ["debug", "display", "from", "try_
 futures-lite = "2.5"
 futures-util = "0.3.25"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "main" }
+iroh-metrics = "0.34"
 libc = "0.2.139"
 nested_enum_utils = "0.2.0"
 netwatch = { version = "0.4.0", path = "../netwatch" }

--- a/portmapper/Cargo.toml
+++ b/portmapper/Cargo.toml
@@ -22,7 +22,7 @@ derive_more = { version = "1.0.0", features = ["debug", "display", "from", "try_
 futures-lite = "2.5"
 futures-util = "0.3.25"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
-iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset" }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "main" }
 libc = "0.2.139"
 nested_enum_utils = "0.2.0"
 netwatch = { version = "0.4.0", path = "../netwatch" }

--- a/portmapper/Cargo.toml
+++ b/portmapper/Cargo.toml
@@ -22,7 +22,7 @@ derive_more = { version = "1.0.0", features = ["debug", "display", "from", "try_
 futures-lite = "2.5"
 futures-util = "0.3.25"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
-iroh-metrics = { version = "0.32", default-features = false }
+iroh-metrics = { version = "0.33", default-features = false }
 libc = "0.2.139"
 nested_enum_utils = "0.2.0"
 netwatch = { version = "0.4.0", path = "../netwatch" }

--- a/portmapper/Cargo.toml
+++ b/portmapper/Cargo.toml
@@ -22,7 +22,7 @@ derive_more = { version = "1.0.0", features = ["debug", "display", "from", "try_
 futures-lite = "2.5"
 futures-util = "0.3.25"
 igd-next = { version = "0.15.1", features = ["aio_tokio"] }
-iroh-metrics = { version = "0.33", default-features = false }
+iroh-metrics = { git = "https://github.com/n0-computer/iroh-metrics", branch = "Frando/derive-metricsgroupset" }
 libc = "0.2.139"
 nested_enum_utils = "0.2.0"
 netwatch = { version = "0.4.0", path = "../netwatch" }

--- a/portmapper/src/lib.rs
+++ b/portmapper/src/lib.rs
@@ -3,6 +3,7 @@
 use std::{
     net::{Ipv4Addr, SocketAddrV4},
     num::NonZeroU16,
+    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -139,7 +140,7 @@ pub struct Client {
     /// Channel used to communicate with the port mapping service.
     service_tx: mpsc::Sender<Message>,
     /// Metrics collected by the service.
-    metrics: Metrics,
+    metrics: Arc<Metrics>,
     /// A handle to the service that will cancel the spawned task once the client is dropped.
     _service_handle: std::sync::Arc<AbortOnDropHandle<()>>,
 }
@@ -157,7 +158,7 @@ impl Client {
     }
 
     /// Creates a new port mapping client with a previously created metrics collector.
-    pub fn with_metrics(config: Config, metrics: Metrics) -> Self {
+    pub fn with_metrics(config: Config, metrics: Arc<Metrics>) -> Self {
         let (service_tx, service_rx) = mpsc::channel(SERVICE_CHANNEL_CAPACITY);
 
         let (service, watcher) = Service::new(config, service_rx, metrics.clone());
@@ -239,7 +240,7 @@ impl Client {
     }
 
     /// Returns the metrics collected by the service.
-    pub fn metrics(&self) -> &Metrics {
+    pub fn metrics(&self) -> &Arc<Metrics> {
         &self.metrics
     }
 }
@@ -273,7 +274,7 @@ impl Probe {
         output: ProbeOutput,
         local_ip: Ipv4Addr,
         gateway: Ipv4Addr,
-        metrics: Metrics,
+        metrics: Arc<Metrics>,
     ) -> Probe {
         let ProbeOutput { upnp, pcp, nat_pmp } = output;
         let Config {
@@ -283,8 +284,9 @@ impl Probe {
         } = config;
         let mut upnp_probing_task = util::MaybeFuture {
             inner: (enable_upnp && !upnp).then(|| {
-                Box::pin(async {
-                    upnp::probe_available()
+                let metrics = metrics.clone();
+                Box::pin(async move {
+                    upnp::probe_available(&metrics)
                         .await
                         .map(|addr| (addr, Instant::now()))
                 })
@@ -373,7 +375,7 @@ impl Probe {
     }
 
     /// Updates a probe with the `Some` values of another probe that is _assumed_ newer.
-    fn update(&mut self, probe: Probe, metrics: &Metrics) {
+    fn update(&mut self, probe: Probe, metrics: &Arc<Metrics>) {
         let Probe {
             last_probe,
             last_upnp_gateway_addr,
@@ -442,16 +444,16 @@ pub struct Service {
     /// Requests for a probe that arrive while this task is still in progress will receive the same
     /// result.
     probing_task: Option<(AbortOnDropHandle<Probe>, Vec<oneshot::Sender<ProbeResult>>)>,
-    metrics: Metrics,
+    metrics: Arc<Metrics>,
 }
 
 impl Service {
     fn new(
         config: Config,
         rx: mpsc::Receiver<Message>,
-        metrics: Metrics,
+        metrics: Arc<Metrics>,
     ) -> (Self, watch::Receiver<Option<SocketAddrV4>>) {
-        let (current_mapping, watcher) = CurrentMapping::new();
+        let (current_mapping, watcher) = CurrentMapping::new(metrics.clone());
         let mut full_probe = Probe::empty();
         if let Some(in_the_past) = full_probe
             .last_probe

--- a/portmapper/src/metrics.rs
+++ b/portmapper/src/metrics.rs
@@ -1,7 +1,4 @@
-use iroh_metrics::{
-    core::{Counter, Metric},
-    struct_iterable::Iterable,
-};
+use iroh_metrics::{struct_iterable::Iterable, Counter, Metric};
 
 /// Enum of metrics for the module
 #[allow(missing_docs)]

--- a/portmapper/src/metrics.rs
+++ b/portmapper/src/metrics.rs
@@ -1,7 +1,8 @@
 use iroh_metrics::{Counter, MetricsGroup};
+use serde::{Deserialize, Serialize};
 
 /// Enum of metrics for the module
-#[derive(Debug, Default, MetricsGroup)]
+#[derive(Debug, Default, MetricsGroup, Serialize, Deserialize)]
 #[metrics(name = "portmap")]
 pub struct Metrics {
     /*

--- a/portmapper/src/metrics.rs
+++ b/portmapper/src/metrics.rs
@@ -1,7 +1,7 @@
 use iroh_metrics::{Counter, MetricsGroup};
 
 /// Enum of metrics for the module
-#[derive(Debug, Clone, MetricsGroup)]
+#[derive(Debug, Default, MetricsGroup)]
 #[metrics(name = "portmap")]
 pub struct Metrics {
     /*

--- a/portmapper/src/metrics.rs
+++ b/portmapper/src/metrics.rs
@@ -1,65 +1,40 @@
-use iroh_metrics::{struct_iterable::Iterable, Counter, MetricsGroup};
+use iroh_metrics::{Counter, MetricsGroup};
 
 /// Enum of metrics for the module
-#[allow(missing_docs)]
-#[derive(Debug, Clone, Iterable)]
+#[derive(Debug, Clone, MetricsGroup)]
+#[metrics_group(name = "portmap")]
 pub struct Metrics {
     /*
      * General port mapping metrics
      */
+    /// Number of probing tasks started.
     pub probes_started: Counter,
+    /// Number of updates to the local port.
     pub local_port_updates: Counter,
+    /// Number of mapping tasks started.
     pub mapping_attempts: Counter,
+    /// Number of failed mapping tasks.
     pub mapping_failures: Counter,
+    /// Number of times the external address obtained via port mapping was updated.
     pub external_address_updated: Counter,
 
     /*
      * UPnP metrics
      */
+    /// Number of UPnP probes executed.
     pub upnp_probes: Counter,
+    /// Number of failed Upnp probes.
     pub upnp_probes_failed: Counter,
+    /// Number of UPnP probes that found it available.
     pub upnp_available: Counter,
+    /// Number of UPnP probes that resulted in a gateway different to the previous one,
     pub upnp_gateway_updated: Counter,
 
     /*
      * PCP metrics
      */
+    /// Number of PCP probes executed.
     pub pcp_probes: Counter,
+    /// Number of PCP probes that found it available.
     pub pcp_available: Counter,
-}
-
-impl Default for Metrics {
-    fn default() -> Self {
-        Self {
-            probes_started: Counter::new("Number of probing tasks started."),
-            local_port_updates: Counter::new("Number of updates to the local port."),
-            mapping_attempts: Counter::new("Number of mapping tasks started."),
-            mapping_failures: Counter::new("Number of failed mapping tasks"),
-            external_address_updated: Counter::new(
-                "Number of times the external address obtained via port mapping was updated.",
-            ),
-
-            /*
-             * UPnP metrics
-             */
-            upnp_probes: Counter::new("Number of UPnP probes executed."),
-            upnp_probes_failed: Counter::new("Number of failed Upnp probes"),
-            upnp_available: Counter::new("Number of UPnP probes that found it available."),
-            upnp_gateway_updated: Counter::new(
-                "Number of UPnP probes that resulted in a gateway different to the previous one.",
-            ),
-
-            /*
-             * PCP metrics
-             */
-            pcp_probes: Counter::new("Number of PCP probes executed."),
-            pcp_available: Counter::new("Number of PCP probes that found it available."),
-        }
-    }
-}
-
-impl MetricsGroup for Metrics {
-    fn name(&self) -> &'static str {
-        "portmap"
-    }
 }

--- a/portmapper/src/metrics.rs
+++ b/portmapper/src/metrics.rs
@@ -2,7 +2,7 @@ use iroh_metrics::{Counter, MetricsGroup};
 
 /// Enum of metrics for the module
 #[derive(Debug, Clone, MetricsGroup)]
-#[metrics_group(name = "portmap")]
+#[metrics(name = "portmap")]
 pub struct Metrics {
     /*
      * General port mapping metrics

--- a/portmapper/src/metrics.rs
+++ b/portmapper/src/metrics.rs
@@ -1,4 +1,4 @@
-use iroh_metrics::{struct_iterable::Iterable, Counter, Metric};
+use iroh_metrics::{struct_iterable::Iterable, Counter, MetricsGroup};
 
 /// Enum of metrics for the module
 #[allow(missing_docs)]
@@ -58,7 +58,7 @@ impl Default for Metrics {
     }
 }
 
-impl Metric for Metrics {
+impl MetricsGroup for Metrics {
     fn name(&self) -> &'static str {
         "portmap"
     }

--- a/portmapper/src/metrics.rs
+++ b/portmapper/src/metrics.rs
@@ -62,7 +62,7 @@ impl Default for Metrics {
 }
 
 impl Metric for Metrics {
-    fn name() -> &'static str {
+    fn name(&self) -> &'static str {
         "portmap"
     }
 }


### PR DESCRIPTION
## Description

Needed for https://github.com/n0-computer/iroh/pull/3262

Updates `iroh-metrics` to 0.34, and makes the metrics collection non-global. Metrics are now collected per portmapper service.

## Breaking Changes

* `portmapper::metrics::Metrics` now implements `MetricsGroup` from `iroh-metrics@0.34`, and no longer implements `Metric` from `iroh-metrics@0.32`.

## Notes & open questions
<!-- Any notes, remarks or open questions you have to make about the PR. -->
## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.