### PR TITLE
fix: Update netdev to 0.37.3 (n0-computer/iroh#3451)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "netdev"
-version = "0.36.0"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862209dce034f82a44c95ce2b5183730d616f2a68746b9c1959aa2572e77c0a1"
+checksum = "daa1e3eaf125c54c21e6221df12dd2a0a682784a068782dd564c836c0f281b6d"
 dependencies = [
  "dlopen2",
  "ipnet",

--- a/netwatch/Cargo.toml
+++ b/netwatch/Cargo.toml
@@ -37,7 +37,7 @@ tracing = "0.1"
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 quinn-udp = { package = "iroh-quinn-udp", version = "0.5.5" }
 libc = "0.2.139"
-netdev = "0.36.0"
+netdev = "0.37.3"
 socket2 = { version = "0.6", features = ["all"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/netwatch/src/interfaces.rs
+++ b/netwatch/src/interfaces.rs
@@ -115,6 +115,7 @@ impl Interface {
                 ipv6_scope_ids: vec![],
                 stats: None,
                 mtu: None,
+                oper_state: netdev::interface::OperState::Up,
             },
         }
     }


### PR DESCRIPTION
## Description
Updates netdev to a version with the cause of n0-computer/iroh#3451 fixed

## Breaking Changes
None

## Change checklist
- [*] Self-review.
- [*] All breaking changes documented.