### PR TITLE
update netdev to 0.38.1 for OpenBSD support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,15 +1199,15 @@ dependencies = [
 
 [[package]]
 name = "netdev"
-version = "0.37.3"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa1e3eaf125c54c21e6221df12dd2a0a682784a068782dd564c836c0f281b6d"
+checksum = "07c1c4a111cf1ba52aa040e77e55fd0e2066d03a3d6ea7d8f383725166a60820"
 dependencies = [
  "dlopen2",
  "ipnet",
  "libc",
- "netlink-packet-core",
- "netlink-packet-route 0.22.0",
+ "netlink-packet-core 0.8.1",
+ "netlink-packet-route 0.25.1",
  "netlink-sys",
  "once_cell",
  "system-configuration",
@@ -1226,18 +1226,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "netlink-packet-route"
-version = "0.22.0"
+name = "netlink-packet-core"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0e7987b28514adf555dc1f9a5c30dfc3e50750bbaffb1aec41ca7b23dcd8e4"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
- "anyhow",
- "bitflags",
- "byteorder",
- "libc",
- "log",
- "netlink-packet-core",
- "netlink-packet-utils",
+ "paste",
 ]
 
 [[package]]
@@ -1251,8 +1245,20 @@ dependencies = [
  "byteorder",
  "libc",
  "log",
- "netlink-packet-core",
+ "netlink-packet-core 0.7.0",
  "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec2f5b6839be2a19d7fa5aab5bc444380f6311c2b693551cb80f45caaa7b5ef"
+dependencies = [
+ "bitflags",
+ "libc",
+ "log",
+ "netlink-packet-core 0.8.1",
 ]
 
 [[package]]
@@ -1276,7 +1282,7 @@ dependencies = [
  "bytes",
  "futures",
  "log",
- "netlink-packet-core",
+ "netlink-packet-core 0.7.0",
  "netlink-sys",
  "thiserror 2.0.17",
 ]
@@ -1309,7 +1315,7 @@ dependencies = [
  "n0-watcher",
  "nested_enum_utils",
  "netdev",
- "netlink-packet-core",
+ "netlink-packet-core 0.7.0",
  "netlink-packet-route 0.24.0",
  "netlink-proto",
  "netlink-sys",

--- a/netwatch/Cargo.toml
+++ b/netwatch/Cargo.toml
@@ -37,7 +37,7 @@ tracing = "0.1"
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 quinn-udp = { package = "iroh-quinn-udp", version = "0.5.5" }
 libc = "0.2.139"
-netdev = "0.37.3"
+netdev = "0.38.1"
 socket2 = { version = "0.6", features = ["all"] }
 tokio = { version = "1", features = [
     "io-util",

--- a/netwatch/src/interfaces.rs
+++ b/netwatch/src/interfaces.rs
@@ -38,7 +38,7 @@ use crate::netmon::is_interesting_interface;
 /// Represents a network interface.
 #[derive(Debug, Clone)]
 pub struct Interface {
-    iface: netdev::interface::Interface,
+    iface: netdev::Interface,
 }
 
 impl fmt::Display for Interface {
@@ -90,7 +90,10 @@ impl Interface {
     pub(crate) fn fake() -> Self {
         use std::net::Ipv4Addr;
 
-        use netdev::{NetworkDevice, interface::InterfaceType, mac::MacAddr};
+        use netdev::{
+            NetworkDevice,
+            prelude::{InterfaceType, MacAddr, OperState},
+        };
 
         Self {
             iface: netdev::Interface {
@@ -115,7 +118,7 @@ impl Interface {
                 ipv6_scope_ids: vec![],
                 stats: None,
                 mtu: None,
-                oper_state: netdev::interface::OperState::Up,
+                oper_state: OperState::Up,
             },
         }
     }
@@ -371,7 +374,7 @@ impl HomeRouter {
     /// This is used as the destination for UPnP, NAT-PMP, PCP, etc queries.
     pub fn new() -> Option<Self> {
         let gateway = Self::get_default_gateway()?;
-        let my_ip = netdev::interface::get_local_ipaddr();
+        let my_ip = netdev::net::ip::get_local_ipaddr();
 
         Some(HomeRouter { gateway, my_ip })
     }


### PR DESCRIPTION
## Description

Updates netdev to the latest release (0.38.1) in order to support OpenBSD

## Breaking Changes
None that I'm aware of

## Notes & open questions
<!-- Any notes, remarks or open questions you have to make about the PR. -->
## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.