### PR TITLE
Add linklocal4 addresses to regular addresses

### DIFF
--- a/netwatch/src/ip.rs
+++ b/netwatch/src/ip.rs
@@ -84,8 +84,7 @@ impl LocalAddresses {
         }
 
         let mut regular = regular4;
-        regular.extend(linklocal4);
-        regular.extend(regular6);
+        regular.extend(linklocal4.into_iter().chain(regular6));
 
         regular.sort();
         loopback.sort();

--- a/netwatch/src/ip.rs
+++ b/netwatch/src/ip.rs
@@ -29,8 +29,8 @@ impl Default for LocalAddresses {
 #[cfg(not(wasm_browser))]
 impl LocalAddresses {
     /// Returns the machine's IP addresses.
-    /// If there are no regular addresses it will return any IPv4 linklocal or IPv6 unique local
-    /// addresses because we know of environments where these are used with NAT to provide connectivity.
+    /// Regular includes all non-loopback IPv4 (including link-local).
+    /// IPv6 link-local and unique local are excluded from regular.
     pub fn new() -> Self {
         let ifaces = netdev::interface::get_interfaces();
         Self::from_raw_interfaces(&ifaces)

--- a/netwatch/src/ip.rs
+++ b/netwatch/src/ip.rs
@@ -83,15 +83,8 @@ impl LocalAddresses {
             }
         }
 
-        if regular4.is_empty() && regular6.is_empty() {
-            // if we have no usable IP addresses then be willing to accept
-            // addresses we otherwise wouldn't, like:
-            //   + 169.254.x.x (AWS Lambda uses NAT with these)
-            //   + IPv6 ULA (Google Cloud Run uses these with address translation)
-            regular4 = linklocal4;
-            regular6 = ula6;
-        }
         let mut regular = regular4;
+        regular.extend(linklocal4);
         regular.extend(regular6);
 
         regular.sort();

--- a/netwatch/src/ip.rs
+++ b/netwatch/src/ip.rs
@@ -17,6 +17,8 @@ pub struct LocalAddresses {
     pub loopback: Vec<IpAddr>,
     /// Regular addresses.
     pub regular: Vec<IpAddr>,
+    /// Link-local addresses (e.g. 169.254.x.x).
+    pub link_local: Vec<IpAddr>,
 }
 
 #[cfg(not(wasm_browser))]
@@ -29,8 +31,8 @@ impl Default for LocalAddresses {
 #[cfg(not(wasm_browser))]
 impl LocalAddresses {
     /// Returns the machine's IP addresses.
-    /// Regular includes all non-loopback IPv4 (including link-local).
-    /// IPv6 link-local and unique local are excluded from regular.
+    /// If there are no regular addresses it will return any IPv4 linklocal or IPv6 unique local
+    /// addresses because we know of environments where these are used with NAT to provide connectivity.
     pub fn new() -> Self {
         let ifaces = netdev::interface::get_interfaces();
         Self::from_raw_interfaces(&ifaces)
@@ -83,13 +85,28 @@ impl LocalAddresses {
             }
         }
 
+        let mut link_local = linklocal4.clone();
+
+        if regular4.is_empty() && regular6.is_empty() {
+            // if we have no usable IP addresses then be willing to accept
+            // addresses we otherwise wouldn't, like:
+            //   + 169.254.x.x (AWS Lambda uses NAT with these)
+            //   + IPv6 ULA (Google Cloud Run uses these with address translation)
+            regular4 = linklocal4;
+            regular6 = ula6;
+        }
         let mut regular = regular4;
-        regular.extend(linklocal4.into_iter().chain(regular6));
+        regular.extend(regular6);
 
         regular.sort();
         loopback.sort();
+        link_local.sort();
 
-        LocalAddresses { loopback, regular }
+        LocalAddresses {
+            loopback,
+            regular,
+            link_local,
+        }
     }
 }
 

--- a/netwatch/src/ip.rs
+++ b/netwatch/src/ip.rs
@@ -17,7 +17,7 @@ pub struct LocalAddresses {
     pub loopback: Vec<IpAddr>,
     /// Regular addresses.
     pub regular: Vec<IpAddr>,
-    /// Link-local addresses (e.g. 169.254.x.x).
+    /// Link-local addresses
     pub link_local: Vec<IpAddr>,
 }
 
@@ -43,6 +43,7 @@ impl LocalAddresses {
         let mut regular4 = Vec::new();
         let mut regular6 = Vec::new();
         let mut linklocal4 = Vec::new();
+        let mut linklocal6 = Vec::new();
         let mut ula6 = Vec::new();
 
         for iface in ifaces {
@@ -65,14 +66,9 @@ impl LocalAddresses {
                 } else if is_link_local(ip) {
                     if ip.is_ipv4() {
                         linklocal4.push(ip);
+                    } else {
+                        linklocal6.push(ip);
                     }
-
-                    // We know of no cases where the IPv6 fe80:: addresses
-                    // are used to provide WAN connectivity. It is also very
-                    // common for users to have no IPv6 WAN connectivity,
-                    // but their OS supports IPv6 so they have an fe80::
-                    // address. We don't want to report all of those
-                    // IPv6 LL to Control.
                 } else if ip.is_ipv6() && is_private(&ip) {
                     // Google Cloud Run uses NAT with IPv6 Unique
                     // Local Addresses to provide IPv6 connectivity.
@@ -86,6 +82,7 @@ impl LocalAddresses {
         }
 
         let mut link_local = linklocal4;
+        link_local.extend(linklocal6);
 
         if regular4.is_empty() && regular6.is_empty() {
             // if we have no usable IP addresses then be willing to accept

--- a/netwatch/src/ip.rs
+++ b/netwatch/src/ip.rs
@@ -85,14 +85,12 @@ impl LocalAddresses {
             }
         }
 
-        let mut link_local = linklocal4.clone();
+        let mut link_local = linklocal4;
 
         if regular4.is_empty() && regular6.is_empty() {
             // if we have no usable IP addresses then be willing to accept
             // addresses we otherwise wouldn't, like:
-            //   + 169.254.x.x (AWS Lambda uses NAT with these)
             //   + IPv6 ULA (Google Cloud Run uses these with address translation)
-            regular4 = linklocal4;
             regular6 = ula6;
         }
         let mut regular = regular4;


### PR DESCRIPTION
## Description
This pull request refactors the IP address collection logic to include IPv4 link-local addresses in the regular addresses list. I'm not sure if this complies with the specifications, but this approach minimizes the required changes to iroh

fix https://github.com/n0-computer/net-tools/issues/49.

## Breaking Changes
## Notes & open questions
## Change checklist
- [ x ] Self-review.
- [ x ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.