### PR TITLE
chore(netwatch): Bump `n0-watcher` dependency to `0.6.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "n0-watcher"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38acf13c1ddafc60eb7316d52213467f8ccb70b6f02b65e7d97f7799b1f50be4"
+checksum = "ba717c22ceec021ace0ff7674bf8fd60c9394605740a8201678fc1cb3a7398f6"
 dependencies = [
  "derive_more 2.0.1",
  "n0-error",

--- a/netwatch/Cargo.toml
+++ b/netwatch/Cargo.toml
@@ -20,7 +20,7 @@ atomic-waker = "1.1.2"
 bytes = "1.7"
 n0-error = "0.1.0"
 n0-future = "0.3.0"
-n0-watcher = "0.5.0"
+n0-watcher = "0.6.0"
 pin-project-lite = "0.2.16"
 time = "0.3.20"
 tokio = { version = "1", features = [


### PR DESCRIPTION
## Description

Bumps the `n0-watcher` version from 0.5.0 to 0.6.0, so we can use it in the multipath branch in iroh (it enables better performance by making `Watcher::peek` available).

## Breaking Changes

- `netwatch::netmon::Monitor::interface_state` now returns a `n0_watcher::Direct` from n0-watcher crate version 0.6.0 instead of 0.5.0, which have different APIs.

<!-- Any notes, remarks or open questions you have to make about the PR. -->
## Change checklist
- [x] Self-review.
- [x] All breaking changes documented.