### PR TITLE
fix(netwatch): ensure ips and other fields are sorted

### DIFF
--- a/netwatch/src/interfaces.rs
+++ b/netwatch/src/interfaces.rs
@@ -223,7 +223,13 @@ impl State {
         let ifaces = netdev::interface::get_interfaces();
         let local_addresses = LocalAddresses::from_raw_interfaces(&ifaces);
 
-        for iface in ifaces {
+        for mut iface in ifaces {
+            // ensure these are all sorted, so any comparisons made are stable
+            iface.ipv4.sort();
+            iface.ipv6.sort();
+            iface.ipv6_scope_ids.sort();
+            iface.dns_servers.sort();
+
             let ni = Interface { iface };
             let if_up = ni.is_up();
             let name = ni.iface.name.clone();


### PR DESCRIPTION
This ensures these don't change order between calls, even if the underlying systems did change ordering.

This is required for some comparisons to be valid