### PR TITLE
fix(netwatch): avoid deadlock for get_default_route on windows

### DIFF
--- a/netwatch/src/interfaces/windows.rs
+++ b/netwatch/src/interfaces/windows.rs
@@ -42,10 +42,15 @@ fn get_default_route() -> Result<DefaultRouteDetails, Error> {
 }
 
 pub async fn default_route() -> Option<DefaultRouteDetails> {
-    match get_default_route() {
-        Ok(route) => Some(route),
-        Err(err) => {
+    // WMI uses COM which can deadlock on a tokio worker thread.
+    match tokio::task::spawn_blocking(get_default_route).await {
+        Ok(Ok(route)) => Some(route),
+        Ok(Err(err)) => {
             warn!("failed to retrieve default route: {:#?}", err);
+            None
+        }
+        Err(err) => {
+            warn!("default route task panicked: {:#?}", err);
             None
         }
     }


### PR DESCRIPTION
Closes #124

