### PR TITLE
test(netwatch): add patchbay network simulation tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,3 +8,12 @@ run-in-isolation = { max-threads = 32 }
 filter = 'test(::run_in_isolation::)'
 test-group = 'run-in-isolation'
 threads-required = 32
+
+[profile.default]
+default-filter = 'not binary(patchbay)'
+
+[profile.patchbay]
+fail-fast = false
+test-threads = 1
+default-filter = 'binary(patchbay)'
+slow-timeout = { period = "30s", terminate-after = 4 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,8 @@ jobs:
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"
     timeout-minutes: 30
     runs-on: [self-hosted, linux, X64]
+    env:
+      RUSTFLAGS: "-Dwarnings --cfg skip_patchbay"
     strategy:
       fail-fast: false
       matrix:
@@ -120,6 +122,8 @@ jobs:
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"
     timeout-minutes: 30
     runs-on: [self-hosted, linux, X64]
+    env:
+      RUSTFLAGS: "-Dwarnings --cfg skip_patchbay"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/patchbay.yml
+++ b/.github/workflows/patchbay.yml
@@ -1,0 +1,56 @@
+name: Patchbay Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: patchbay-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  RUST_BACKTRACE: 1
+  SCCACHE_CACHE_SIZE: "10G"
+
+jobs:
+  patchbay_tests:
+    name: Patchbay Tests
+    timeout-minutes: 15
+    runs-on: [self-hosted, linux, X64]
+    env:
+      RUSTC_WRAPPER: "sccache"
+    steps:
+      - name: Enable unprivileged user namespaces
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        continue-on-error: true
+
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Install cargo-make and cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.80,cargo-make
+
+      - name: Build patchbay tests
+        run: cargo make patchbay --no-run
+
+      - name: Run patchbay tests
+        run: |
+          set -o pipefail
+          cargo make patchbay 2>&1 | tee "$RUNNER_TEMP/logs.txt"
+        env:
+          PATCHBAY_LOG: trace
+          RUST_LOG: trace
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: patchbay-testdir-${{ github.sha }}
+          path: |
+            ${{ runner.temp }}/logs.txt
+          retention-days: 7
+          if-no-files-found: ignore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,9 +1542,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -208,6 +208,22 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "ctor"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "deranged"
@@ -280,6 +296,21 @@ dependencies = [
  "once_cell",
  "winapi",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1057d6c64987086ff8ed0fd3fbf377a6b7d205cc7715868cd401705f715cbe4"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "embedded-io"
@@ -798,6 +829,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iroh-metrics"
@@ -1011,7 +1045,7 @@ dependencies = [
  "libc",
  "mac-addr",
  "netlink-packet-core",
- "netlink-packet-route",
+ "netlink-packet-route 0.29.0",
  "netlink-sys",
  "objc2-core-foundation",
  "objc2-system-configuration",
@@ -1027,6 +1061,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
  "paste",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
+dependencies = [
+ "bitflags",
+ "libc",
+ "log",
+ "netlink-packet-core",
 ]
 
 [[package]]
@@ -1052,7 +1098,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1075,6 +1121,7 @@ dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases",
+ "ctor",
  "derive_more",
  "js-sys",
  "libc",
@@ -1083,12 +1130,13 @@ dependencies = [
  "n0-watcher",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route",
+ "netlink-packet-route 0.29.0",
  "netlink-proto",
  "netlink-sys",
  "noq-udp",
  "objc2-core-foundation",
  "objc2-system-configuration",
+ "patchbay",
  "pin-project-lite",
  "serde",
  "socket2",
@@ -1104,6 +1152,18 @@ dependencies = [
  "windows",
  "windows-result",
  "wmi",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -1275,6 +1335,31 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "patchbay"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d93ad32b57e2d0185284b2e73817b3668feb3013ee70e963d1cb01dda53a8a"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "derive_more",
+ "futures",
+ "ipnet",
+ "libc",
+ "nix",
+ "rtnetlink",
+ "serde",
+ "serde_json",
+ "strum",
+ "tokio",
+ "tokio-util",
+ "toml",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1500,6 +1585,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rtnetlink"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route 0.28.0",
+ "netlink-proto",
+ "netlink-sys",
+ "nix",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,6 +1700,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1676,6 +1788,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1716,11 +1849,31 @@ checksum = "614b328ff036a4ef882c61570f72918f7e9c5bee1da33f8e7f91e01daee7e56c"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1826,10 +1979,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+name = "toml"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -1843,17 +2011,23 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower-layer"
@@ -2340,6 +2514,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,7 +2617,7 @@ dependencies = [
  "futures",
  "log",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "windows",
  "windows-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ missing_debug_implementations = "warn"
 # require a feature enabled when using `--cfg docsrs` which we can not
 # do.  To enable for a crate set `#![cfg_attr(iroh_docsrs,
 # feature(doc_cfg))]` in the crate.
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)"] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(iroh_docsrs)", "cfg(skip_patchbay)"] }
 
 [workspace.lints.clippy]
 unused-async = "warn"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -13,6 +13,11 @@ args = [
      "imports_granularity=Crate,group_imports=StdExternalCrate,reorder_imports=true,format_code_in_doc_comments=true",
 ]
 
+[tasks.patchbay]
+workspace = false
+command = "cargo"
+args = ["nextest", "run", "-p", "netwatch", "--test", "patchbay", "--profile", "patchbay", "${@}"]
+
 [tasks.format-check]
 workspace = false
 command = "cargo"

--- a/netwatch/Cargo.toml
+++ b/netwatch/Cargo.toml
@@ -81,6 +81,10 @@ web-sys = { version = "0.3.83", features = ["EventListener", "EventTarget"] }
 testresult = "0.4.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+patchbay = "0.3"
+ctor = "0.8"
+
 # *non*-wasm-in-browser test/dev dependencies
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
 tokio = { version = "1", features = [

--- a/netwatch/tests/patchbay.rs
+++ b/netwatch/tests/patchbay.rs
@@ -1,0 +1,112 @@
+//! Patchbay network simulation tests for netwatch.
+//!
+//! These tests use the [`patchbay`] crate to create virtual network topologies
+//! in Linux user namespaces, testing netwatch's interface and route detection
+//! under various network conditions.
+//!
+//! To run:
+//! ```sh
+//! cargo make patchbay
+//! ```
+
+#![cfg(all(target_os = "linux", not(skip_patchbay)))]
+
+use netwatch::interfaces::State;
+use patchbay::{IpSupport, Lab};
+use testresult::TestResult;
+
+/// Init the user namespace before any threads are spawned.
+#[ctor::ctor]
+fn userns_ctor() {
+    patchbay::init_userns().expect("failed to init userns");
+}
+
+/// Creates a new lab with a single device connected to a router.
+///
+/// `ip_support` is the IP support of the router to which the device is connected.
+///
+/// Returns the [`State`] for the device.
+async fn state_for_routed_device(ip_support: IpSupport) -> TestResult<State> {
+    let lab = Lab::new().await?;
+    let router = lab
+        .add_router("router")
+        .ip_support(ip_support)
+        .build()
+        .await?;
+    let device = lab.add_device("device").uplink(router.id()).build().await?;
+    let state = device.spawn(|_| State::new())?.await?;
+    Ok(state)
+}
+
+/// Netwatch detects a default route on a v4-only network.
+#[tokio::test]
+async fn default_route_v4_only() -> TestResult {
+    let state = state_for_routed_device(IpSupport::V4Only).await?;
+
+    assert!(state.have_v4, "should have v4");
+    assert!(!state.have_v6, "should not have v6");
+    assert_eq!(state.default_route_interface.as_deref(), Some("eth0"));
+    Ok(())
+}
+
+/// Netwatch detects a default route on a v6-only network.
+#[tokio::test]
+#[ignore = "default_route() does not fall through to netlink when /proc/net/route has no IPv4 default"]
+async fn default_route_v6_only() -> TestResult {
+    let state = state_for_routed_device(IpSupport::V6Only).await?;
+
+    assert!(!state.have_v4, "should not have v4");
+    assert!(state.have_v6, "should have v6");
+    assert_eq!(state.default_route_interface.as_deref(), Some("eth0"));
+    Ok(())
+}
+
+/// Netwatch detects a default route on a dual-stack network.
+#[tokio::test]
+async fn default_route_dual_stack() -> TestResult {
+    let state = state_for_routed_device(IpSupport::DualStack).await?;
+
+    assert!(state.have_v4, "should have v4");
+    assert!(state.have_v6, "should have v6");
+    assert_eq!(state.default_route_interface.as_deref(), Some("eth0"));
+    Ok(())
+}
+
+/// After replugging from a v4 router to a v6 router, netwatch detects the new
+/// default route.
+#[tokio::test]
+#[ignore = "default_route() does not fall through to netlink when /proc/net/route has no IPv4 default"]
+async fn default_route_after_replug_v4_to_v6() -> TestResult {
+    let lab = Lab::new().await?;
+    let v4_router = lab
+        .add_router("v4")
+        .ip_support(IpSupport::V4Only)
+        .build()
+        .await?;
+    let v6_router = lab
+        .add_router("v6")
+        .ip_support(IpSupport::V6Only)
+        .build()
+        .await?;
+    let device = lab
+        .add_device("device")
+        .uplink(v4_router.id())
+        .build()
+        .await?;
+
+    // Verify the initial v4 state.
+    let state = device.spawn(|_| State::new())?.await?;
+    assert!(state.have_v4, "should have v4");
+    assert!(!state.have_v6, "should not have v6");
+    assert_eq!(state.default_route_interface.as_deref(), Some("eth0"));
+
+    // Replug from the v4 router to the v6 router.
+    device.replug_iface("eth0", v6_router.id()).await?;
+
+    let state = device.spawn(|_| State::new())?.await?;
+    assert!(!state.have_v4, "should not have v4");
+    assert!(state.have_v6, "should have v6");
+    assert_eq!(state.default_route_interface.as_deref(), Some("eth0"));
+
+    Ok(())
+}


### PR DESCRIPTION
## Description

Add patchbay tests that exercise netwatch's interface and route detection inside virtual network namespaces. The tests cover v4-only, v6-only, dual-stack, and v4-to-v6 replug scenarios.


Also adds patchbay CI workflow, nextest patchbay profile, and a cargo-make task to match the iroh project's patchbay setup.

## Notes & open questions

Two of the four tests are currently ignored: they expose a bug where default_route() fails to detect IPv6 default routes on Linux because /proc/net/route only contains IPv4 entries and the netlink fallback is never reached.
See #132 for a fix.
<!-- Any notes, remarks or open questions you have to make about the PR. -->
## Change checklist
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.