### PR TITLE
fix(netwatch): detect IPv6 default routes on Linux

### DIFF
--- a/netwatch/src/interfaces/linux.rs
+++ b/netwatch/src/interfaces/linux.rs
@@ -41,9 +41,11 @@ pub enum Error {
 }
 
 pub async fn default_route() -> Option<DefaultRouteDetails> {
-    let route = default_route_proc().await;
-    if let Ok(route) = route {
-        return route;
+    // /proc/net/route only contains IPv4 routes. If it finds one, return it.
+    // If it returns Ok(None) (no IPv4 default route) or Err (file unreadable),
+    // fall through to netlink which checks both IPv4 and IPv6.
+    if let Ok(Some(route)) = default_route_proc().await {
+        return Some(route);
     }
 
     #[cfg(target_os = "android")]

--- a/netwatch/tests/patchbay.rs
+++ b/netwatch/tests/patchbay.rs
@@ -51,7 +51,6 @@ async fn default_route_v4_only() -> TestResult {
 
 /// Netwatch detects a default route on a v6-only network.
 #[tokio::test]
-#[ignore = "default_route() does not fall through to netlink when /proc/net/route has no IPv4 default"]
 async fn default_route_v6_only() -> TestResult {
     let state = state_for_routed_device(IpSupport::V6Only).await?;
 
@@ -75,7 +74,6 @@ async fn default_route_dual_stack() -> TestResult {
 /// After replugging from a v4 router to a v6 router, netwatch detects the new
 /// default route.
 #[tokio::test]
-#[ignore = "default_route() does not fall through to netlink when /proc/net/route has no IPv4 default"]
 async fn default_route_after_replug_v4_to_v6() -> TestResult {
     let lab = Lab::new().await?;
     let v4_router = lab


### PR DESCRIPTION
## Description

`default_route()` is special-cased on linux to not use rtnetlink but read `/proc/net/route` first, which contains only IPv4 entries. When no IPv4 default route exists it returns `Ok(None)`, and the code treated any Ok result as final without falling through to the netlink-based detection that handles both address families.

On a v6-only network this made default_route_interface permanently `None`, which caused iroh's `has_usable_network()` to return false after network switches. 

The fix narrows the early return to Ok(Some(..)) so that Ok(None) falls through to the netlink path.

<!-- A summary of what this pull request achieves and a rough list of changes. -->
## Breaking Changes
<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
## Notes & open questions

Why do we even special case linux here and not just rely on rtnetlink always?

## Change checklist
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.