### PR TITLE
fix: set SO_REUSEADDR to avoid "address already in use" on bind

### DIFF
--- a/netwatch/src/udp.rs
+++ b/netwatch/src/udp.rs
@@ -746,6 +746,12 @@ impl SocketState {
             socket.set_only_v6(true)?;
         }
 
+        // Allow rebinding to an address still in TIME_WAIT
+        #[cfg(unix)]
+        if let Err(err) = socket.set_reuse_address(true) {
+            debug!("failed to set SO_REUSEADDR: {:?}", err);
+        }
+
         // Binding must happen before calling noq, otherwise `local_addr`
         // is not yet available on all OSes.
         socket.bind(&addr.into())?;


### PR DESCRIPTION
## Description

On embedded Linux, switching between Wi-Fi STA and AP modes triggers a network-change rebind. The rebind fails with `EADDRINUSE` because the OS hasn't fully released the port during interface teardown, leaving the UDP socket permanently closed and the iroh endpoint unrecoverable.

log:

```
2026-04-24T01:08:47.719273Z DEBUG endpoint{id=8c2ce75b61}:actor: iroh::socket: link change detected is_major=true
2026-04-24T01:08:47.720117Z  WARN endpoint{id=8c2ce75b61}:actor: iroh::socket::transports: failed to rebind Os { code: 98, kind: AddrInUse, message: "Address in use" }
2026-04-24T01:08:47.720728Z  WARN endpoint{id=8c2ce75b61}:actor: iroh::socket::transports: failed to rebind Os { code: 98, kind: AddrInUse, message: "Address in use" }
2026-04-24T01:08:47.720945Z  WARN endpoint{id=8c2ce75b61}:actor: iroh::socket: failed to rebind transports: Os { code: 98, kind: AddrInUse, message: "Address in use" }
2026-04-24T01:08:47.723957Z DEBUG endpoint{id=8c2ce75b61}:actor: iroh::socket: starting direct addr update (LinkChangeMajor)
2026-04-24T01:08:47.724228Z DEBUG endpoint{id=8c2ce75b61}:actor: iroh::socket: requesting net_report report
2026-04-24T01:08:47.727649Z  WARN poll_send{dst=Ip(192.168.1.164:55519) src=None len=40}: netwatch::udp: socket closed
2026-04-24T01:08:47.727827Z  WARN iroh::socket::transports: dropped transmit: socket closed dst=Ip(192.168.1.164:55519)
2026-04-24T01:08:47.728197Z  WARN poll_send{dst=Ip([240e:3b7:1eed:b520:5dbf:21e4:de27:4518]:55521) src=None len=30}: netwatch::udp: socket closed
2026-04-24T01:08:47.728389Z  WARN iroh::socket::transports: dropped transmit: socket closed dst=Ip([240e:3b7:1eed:b520:5dbf:21e4:de27:4518]:55521)
2026-04-24T01:08:47.728967Z DEBUG endpoint{id=8c2ce75b61}:actor: iroh::net_report: net_report starting do_full=true
2026-04-24T01:08:47.731698Z  WARN endpoint{id=8c2ce75b61}: netwatch::udp: socket closed
2026-04-24T01:08:47.731912Z ERROR endpoint{id=8c2ce75b61}: noq::endpoint: I/O error: socket closed
```

Set `SO_REUSEADDR` before `bind()` on Unix so the rebind can succeed even if the OS has not yet fully released the port.

## Breaking Changes

None.

## Notes & open questions

None.

## Change checklist
- [ x ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.