### PR TITLE
fix(netwatch): compilation for all Apple targets

### DIFF
--- a/netwatch/Cargo.toml
+++ b/netwatch/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1", features = [
     "time",
 ] }
 
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 # msrv fix
 objc2-core-foundation = "0.3.2"
 objc2-system-configuration = "0.3.2"

--- a/netwatch/src/interfaces.rs
+++ b/netwatch/src/interfaces.rs
@@ -8,8 +8,7 @@ use n0_future::time::Instant;
     target_os = "freebsd",
     target_os = "openbsd",
     target_os = "netbsd",
-    target_os = "macos",
-    target_os = "ios"
+    target_vendor = "apple",
 ))]
 pub(super) mod bsd;
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -24,8 +23,7 @@ pub(crate) use netdev::ipnet::{Ipv4Net, Ipv6Net};
     target_os = "freebsd",
     target_os = "openbsd",
     target_os = "netbsd",
-    target_os = "macos",
-    target_os = "ios"
+    target_vendor = "apple",
 ))]
 use self::bsd::default_route;
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -455,8 +453,7 @@ impl HomeRouter {
         target_os = "freebsd",
         target_os = "openbsd",
         target_os = "netbsd",
-        target_os = "macos",
-        target_os = "ios"
+        target_vendor = "apple",
     ))]
     fn get_default_gateway() -> Option<IpAddr> {
         // netdev doesn't work yet

--- a/netwatch/src/interfaces/bsd.rs
+++ b/netwatch/src/interfaces/bsd.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use libc::{AF_INET, AF_INET6, AF_LINK, AF_ROUTE, AF_UNSPEC, CTL_NET, c_int, uintptr_t};
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_vendor = "apple")]
 use libc::{
     NET_RT_DUMP, RTA_IFP, RTAX_BRD, RTAX_DST, RTAX_GATEWAY, RTAX_MAX, RTAX_NETMASK, RTF_GATEWAY,
 };
@@ -31,9 +31,9 @@ mod openbsd;
 #[cfg(target_os = "openbsd")]
 pub(crate) use self::openbsd::*;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_vendor = "apple")]
 mod macos;
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_vendor = "apple")]
 use self::macos::*;
 
 pub async fn default_route() -> Option<DefaultRouteDetails> {
@@ -103,7 +103,7 @@ fn is_default_gateway(rm: &RouteMessage) -> bool {
         return false;
     }
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(target_vendor = "apple")]
     if rm.flags & libc::RTF_IFSCOPE as u32 != 0 {
         return false;
     }
@@ -167,7 +167,7 @@ fn parse_routing_table(rib: &[u8]) -> Option<Vec<RouteMessage>> {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios",))]
+#[cfg(target_vendor = "apple")]
 fn fetch_routing_table() -> Option<Vec<u8>> {
     const NET_RT_DUMP2: i32 = 7;
     match fetch_rib(libc::AF_UNSPEC, NET_RT_DUMP2, 0) {
@@ -179,7 +179,7 @@ fn fetch_routing_table() -> Option<Vec<u8>> {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios",))]
+#[cfg(target_vendor = "apple")]
 fn parse_routing_table(rib: &[u8]) -> Option<Vec<RouteMessage>> {
     match parse_rib(libc::NET_RT_IFLIST2, rib) {
         Ok(res) => {
@@ -199,7 +199,7 @@ fn parse_routing_table(rib: &[u8]) -> Option<Vec<RouteMessage>> {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_vendor = "apple")]
 const fn is_valid_rib_type(typ: RIBType) -> bool {
     const NET_RT_STAT: RIBType = 4;
     const NET_RT_TRASH: RIBType = 5;
@@ -265,12 +265,7 @@ fn u32_from_ne_range(
 impl WireFormat {
     fn parse(&self, _typ: RIBType, data: &[u8]) -> Result<Option<WireMessage>, RouteError> {
         match self.typ {
-            #[cfg(any(
-                target_os = "freebsd",
-                target_os = "netbsd",
-                target_os = "macos",
-                target_os = "ios"
-            ))]
+            #[cfg(any(target_os = "freebsd", target_os = "netbsd", target_vendor = "apple"))]
             MessageType::Route => {
                 ensure!(data.len() >= self.body_off, RouteError::MessageTooShort);
                 let l = u16_from_ne_range(data, ..2)?;
@@ -874,14 +869,14 @@ fn parse_kernel_inet_addr(af: i32, b: &[u8]) -> Result<(i32, Addr), RouteError> 
     //   the routing message boundary
     let mut l = b[0] as usize;
 
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(target_vendor = "apple")]
     {
         // On Darwin, an address in the kernel form is also used as a message filler.
         if l == 0 || b.len() > roundup(l) {
             l = roundup(l)
         }
     }
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    #[cfg(not(target_vendor = "apple"))]
     {
         l = roundup(l);
     }
@@ -1028,7 +1023,7 @@ mod tests {
         buf[2] = wrong_version;
         buf[3] = 0; // arbitrary type
 
-        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        #[cfg(target_vendor = "apple")]
         let rib_type = libc::NET_RT_IFLIST2;
         #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
         let rib_type = libc::NET_RT_IFLIST;
@@ -1063,7 +1058,7 @@ mod tests {
     #[test]
     #[cfg(target_endian = "little")]
     fn test_parse_addrs() {
-        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        #[cfg(target_vendor = "apple")]
         use libc::{RTA_BRD, RTA_DST, RTA_GATEWAY, RTA_IFA, RTA_IFP, RTA_NETMASK};
 
         let parse_addrs_little_endian_tests = [

--- a/netwatch/src/netmon.rs
+++ b/netwatch/src/netmon.rs
@@ -12,8 +12,7 @@ mod android;
     target_os = "freebsd",
     target_os = "openbsd",
     target_os = "netbsd",
-    target_os = "macos",
-    target_os = "ios"
+    target_vendor = "apple",
 ))]
 mod bsd;
 #[cfg(target_os = "linux")]

--- a/netwatch/src/netmon/actor.rs
+++ b/netwatch/src/netmon/actor.rs
@@ -13,8 +13,7 @@ use super::android as os;
     target_os = "freebsd",
     target_os = "openbsd",
     target_os = "netbsd",
-    target_os = "macos",
-    target_os = "ios"
+    target_vendor = "apple",
 ))]
 use super::bsd as os;
 #[cfg(target_os = "linux")]

--- a/netwatch/src/netmon/bsd.rs
+++ b/netwatch/src/netmon/bsd.rs
@@ -1,4 +1,4 @@
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_vendor = "apple")]
 use libc::{RTAX_DST, RTAX_IFP};
 use n0_error::stack_error;
 use n0_future::{


### PR DESCRIPTION
## Description

Fix `netwatch` cfg gates so the Darwin/BSD implementation is enabled for all Apple targets via `target_vendor = "apple"`, instead of only `macos` and `ios`.

This covers Apple targets such as watchOS, tvOS, and visionOS at compile time by applying the same Apple routing implementation and target-specific dependencies consistently.

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.