### PR TITLE
freebsd.rs: fix build on powerpc64* and riscv64

### DIFF
--- a/netwatch/src/interfaces/bsd/freebsd.rs
+++ b/netwatch/src/interfaces/bsd/freebsd.rs
@@ -203,9 +203,9 @@ mod arm {
 }
 
 // Hardcoded based on the generated values here: https://cs.opensource.google/go/x/net/+/master:route/zsys_freebsd_arm.go
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64"))]
 pub use self::arm64::*;
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "powerpc64", target_arch = "riscv64"))]
 mod arm64 {
     pub const SIZEOF_IF_MSGHDRL_FREE_BSD10: usize = 0xb0;
     pub const SIZEOF_IFA_MSGHDR_FREE_BSD10: usize = 0x14;


### PR DESCRIPTION
## Description
The values in that file apply also on powerpc64* and should work on riscv64 as well. Tested on powerpc64le.
## Breaking Changes
None
## Notes & open questions
None
## Change checklist
- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.