### PR TITLE
feat: add support for powerpc64 and riscv64

### DIFF
--- a/netwatch/src/interfaces/bsd/freebsd.rs
+++ b/netwatch/src/interfaces/bsd/freebsd.rs
@@ -208,13 +208,13 @@ mod arm {
     target_arch = "powerpc64",
     target_arch = "riscv64"
 ))]
-pub use self::arm64::*;
+pub use self::lp64::*;
 #[cfg(any(
     target_arch = "aarch64",
     target_arch = "powerpc64",
     target_arch = "riscv64"
 ))]
-mod arm64 {
+mod lp64 {
     pub const SIZEOF_IF_MSGHDRL_FREE_BSD10: usize = 0xb0;
     pub const SIZEOF_IFA_MSGHDR_FREE_BSD10: usize = 0x14;
     pub const SIZEOF_IFA_MSGHDRL_FREE_BSD10: usize = 0xb0;

--- a/netwatch/src/interfaces/bsd/freebsd.rs
+++ b/netwatch/src/interfaces/bsd/freebsd.rs
@@ -203,9 +203,17 @@ mod arm {
 }
 
 // Hardcoded based on the generated values here: https://cs.opensource.google/go/x/net/+/master:route/zsys_freebsd_arm.go
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "powerpc64",
+    target_arch = "riscv64"
+))]
 pub use self::arm64::*;
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "powerpc64",
+    target_arch = "riscv64"
+))]
 mod arm64 {
     pub const SIZEOF_IF_MSGHDRL_FREE_BSD10: usize = 0xb0;
     pub const SIZEOF_IFA_MSGHDR_FREE_BSD10: usize = 0x14;


### PR DESCRIPTION
## Description

Add support for powerpc64 and riscv64. See https://github.com/n0-computer/net-tools/pull/159

## Breaking Changes

None

## Notes & open questions

Note: we rename the module from arm64 to lp64 so it is clear that this now covers more than one arch.

Note: it seems at first glance that the amd64 module is identical, it could be removed and also covered by the lp64 module. But we will do this in a subsequent PR.