### PR TITLE
feat(netwatch): allow setting SO_MARK on UdpSocket

### DIFF
--- a/netwatch/src/lib.rs
+++ b/netwatch/src/lib.rs
@@ -12,4 +12,4 @@ mod udp;
 
 pub use self::ip_family::IpFamily;
 #[cfg(not(wasm_browser))]
-pub use self::udp::{UdpSender, UdpSocket};
+pub use self::udp::{BindOptions, UdpSender, UdpSocket};

--- a/netwatch/src/udp.rs
+++ b/netwatch/src/udp.rs
@@ -52,18 +52,31 @@ impl UdpSocket {
     /// Bind to the given port only on localhost.
     pub fn bind_local(network: IpFamily, port: u16) -> io::Result<Self> {
         let addr = SocketAddr::new(network.local_addr(), port);
-        Self::bind_raw(addr)
+        Self::bind_raw(addr, None)
     }
 
     /// Bind to the given port and listen on all interfaces.
     pub fn bind(network: IpFamily, port: u16) -> io::Result<Self> {
         let addr = SocketAddr::new(network.unspecified_addr(), port);
-        Self::bind_raw(addr)
+        Self::bind_raw(addr, None)
     }
 
     /// Bind to any provided [`SocketAddr`].
     pub fn bind_full(addr: impl Into<SocketAddr>) -> io::Result<Self> {
-        Self::bind_raw(addr)
+        Self::bind_raw(addr, None)
+    }
+
+    /// Bind to any provided [`SocketAddr`], applying an fwmark to the socket.
+    ///
+    /// `mark` is applied via `SO_MARK` on Linux (and reapplied on every rebind)
+    /// so the caller can policy-route this socket's egress, for example around a
+    /// full-tunnel default route. `None` leaves the socket unmarked; the mark is
+    /// a no-op on non-Linux platforms.
+    pub fn bind_full_with_mark(
+        addr: impl Into<SocketAddr>,
+        mark: Option<u32>,
+    ) -> io::Result<Self> {
+        Self::bind_raw(addr, mark)
     }
 
     /// Is the socket broken and needs a rebind?
@@ -96,8 +109,8 @@ impl UdpSocket {
         Ok(())
     }
 
-    fn bind_raw(addr: impl Into<SocketAddr>) -> io::Result<Self> {
-        let socket = SocketState::bind(addr.into())?;
+    fn bind_raw(addr: impl Into<SocketAddr>, mark: Option<u32>) -> io::Result<Self> {
+        let socket = SocketState::bind(addr.into(), mark)?;
 
         Ok(UdpSocket {
             socket: RwLock::new(socket),
@@ -736,10 +749,14 @@ enum SocketState {
         state: noq_udp::UdpSocketState,
         /// The addr we are binding to.
         addr: SocketAddr,
+        /// The fwmark to (re)apply to the socket, if any.
+        mark: Option<u32>,
     },
     Closed {
         /// The addr to rebind to when recovering.
         addr: SocketAddr,
+        /// The fwmark to reapply when rebinding, if any.
+        mark: Option<u32>,
         last_max_gso_segments: NonZeroUsize,
         last_gro_segments: NonZeroUsize,
         last_may_fragment: bool,
@@ -753,6 +770,7 @@ impl SocketState {
                 socket,
                 state,
                 addr: _,
+                mark: _,
             } => Ok((socket, state)),
             Self::Closed { .. } => {
                 warn!("socket closed");
@@ -761,7 +779,7 @@ impl SocketState {
         }
     }
 
-    fn bind(addr: SocketAddr) -> io::Result<Self> {
+    fn bind(addr: SocketAddr, mark: Option<u32>) -> io::Result<Self> {
         let network = IpFamily::from(addr.ip());
         let socket = socket2::Socket::new(
             network.into(),
@@ -785,6 +803,16 @@ impl SocketState {
             // Avoid dualstack
             socket.set_only_v6(true)?;
         }
+
+        // Apply the fwmark, if set. Linux-only; a no-op elsewhere.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        if let Some(mark) = mark {
+            if let Err(err) = socket.set_mark(mark) {
+                warn!("failed to set SO_MARK {} on udp socket: {:?}", mark, err);
+            }
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
+        let _ = mark;
 
         // Binding must happen before calling noq, otherwise `local_addr`
         // is not yet available on all OSes.
@@ -814,13 +842,14 @@ impl SocketState {
             socket,
             state: socket_state,
             addr: local_addr,
+            mark,
         })
     }
 
     fn rebind(&mut self) -> io::Result<()> {
-        let addr = match self {
-            Self::Connected { addr, .. } => *addr,
-            Self::Closed { addr, .. } => *addr,
+        let (addr, mark) = match self {
+            Self::Connected { addr, mark, .. } => (*addr, *mark),
+            Self::Closed { addr, mark, .. } => (*addr, *mark),
         };
         debug!("rebinding {}", addr);
 
@@ -829,13 +858,14 @@ impl SocketState {
         if let Self::Connected { state, .. } = self {
             *self = SocketState::Closed {
                 addr,
+                mark,
                 last_max_gso_segments: state.max_gso_segments(),
                 last_gro_segments: state.gro_segments(),
                 last_may_fragment: state.may_fragment(),
             };
         }
 
-        match Self::bind(addr) {
+        match Self::bind(addr, mark) {
             Ok(new_state) => {
                 *self = new_state;
                 Ok(())
@@ -854,9 +884,12 @@ impl SocketState {
 
     fn close(&mut self) -> Option<(tokio::net::UdpSocket, noq_udp::UdpSocketState)> {
         match self {
-            Self::Connected { state, addr, .. } => {
+            Self::Connected {
+                state, addr, mark, ..
+            } => {
                 let s = SocketState::Closed {
                     addr: *addr,
+                    mark: *mark,
                     last_max_gso_segments: state.max_gso_segments(),
                     last_gro_segments: state.gro_segments(),
                     last_may_fragment: state.may_fragment(),

--- a/netwatch/src/udp.rs
+++ b/netwatch/src/udp.rs
@@ -28,6 +28,36 @@ pub struct UdpSocket {
 /// UDP socket read/write buffer size (7MB). The value of 7MB is chosen as it
 /// is the max supported by a default configuration of macOS. Some platforms will silently clamp the value.
 const SOCKET_BUFFER_SIZE: usize = 7 << 20;
+
+/// Options to bind a [`UdpSocket`] with.
+///
+/// Used by [`UdpSocket::bind_with`]. The default options match what the other
+/// `bind_*` constructors use.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct BindOptions {
+    mark: Option<u32>,
+}
+
+impl BindOptions {
+    /// Creates the default options.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the fwmark to apply to the socket, or `None` to leave it unmarked.
+    ///
+    /// The mark is applied with `SO_MARK` and is reapplied whenever the socket is
+    /// rebound, so the caller can policy-route the socket's egress, for example
+    /// around a full-tunnel default route.
+    ///
+    /// This only has an effect on Linux and Android. On every other platform the
+    /// mark is ignored.
+    pub fn set_mark(mut self, mark: Option<u32>) -> Self {
+        self.mark = mark;
+        self
+    }
+}
+
 impl UdpSocket {
     /// Bind only Ipv4 on any interface.
     pub fn bind_v4(port: u16) -> io::Result<Self> {
@@ -52,31 +82,30 @@ impl UdpSocket {
     /// Bind to the given port only on localhost.
     pub fn bind_local(network: IpFamily, port: u16) -> io::Result<Self> {
         let addr = SocketAddr::new(network.local_addr(), port);
-        Self::bind_raw(addr, None)
+        Self::bind_with(addr, BindOptions::default())
     }
 
     /// Bind to the given port and listen on all interfaces.
     pub fn bind(network: IpFamily, port: u16) -> io::Result<Self> {
         let addr = SocketAddr::new(network.unspecified_addr(), port);
-        Self::bind_raw(addr, None)
+        Self::bind_with(addr, BindOptions::default())
     }
 
     /// Bind to any provided [`SocketAddr`].
     pub fn bind_full(addr: impl Into<SocketAddr>) -> io::Result<Self> {
-        Self::bind_raw(addr, None)
+        Self::bind_with(addr, BindOptions::default())
     }
 
-    /// Bind to any provided [`SocketAddr`], applying an fwmark to the socket.
-    ///
-    /// `mark` is applied via `SO_MARK` on Linux (and reapplied on every rebind)
-    /// so the caller can policy-route this socket's egress, for example around a
-    /// full-tunnel default route. `None` leaves the socket unmarked; the mark is
-    /// a no-op on non-Linux platforms.
-    pub fn bind_full_with_mark(
-        addr: impl Into<SocketAddr>,
-        mark: Option<u32>,
-    ) -> io::Result<Self> {
-        Self::bind_raw(addr, mark)
+    /// Bind to any provided [`SocketAddr`], using the given [`BindOptions`].
+    pub fn bind_with(addr: impl Into<SocketAddr>, opts: BindOptions) -> io::Result<Self> {
+        let socket = SocketState::bind(addr.into(), opts.mark)?;
+
+        Ok(UdpSocket {
+            socket: RwLock::new(socket),
+            recv_waker: AtomicWaker::default(),
+            send_waker: AtomicWaker::default(),
+            is_broken: AtomicBool::new(false),
+        })
     }
 
     /// Is the socket broken and needs a rebind?
@@ -107,17 +136,6 @@ impl UdpSocket {
         self.wake_all();
 
         Ok(())
-    }
-
-    fn bind_raw(addr: impl Into<SocketAddr>, mark: Option<u32>) -> io::Result<Self> {
-        let socket = SocketState::bind(addr.into(), mark)?;
-
-        Ok(UdpSocket {
-            socket: RwLock::new(socket),
-            recv_waker: AtomicWaker::default(),
-            send_waker: AtomicWaker::default(),
-            is_broken: AtomicBool::new(false),
-        })
     }
 
     /// Receives a single datagram message on the socket from the remote address
@@ -804,12 +822,12 @@ impl SocketState {
             socket.set_only_v6(true)?;
         }
 
-        // Apply the fwmark, if set. Linux-only; a no-op elsewhere.
+        // Apply the fwmark, if set. Only supported on linux and android.
         #[cfg(any(target_os = "linux", target_os = "android"))]
-        if let Some(mark) = mark {
-            if let Err(err) = socket.set_mark(mark) {
-                warn!("failed to set SO_MARK {} on udp socket: {:?}", mark, err);
-            }
+        if let Some(mark) = mark
+            && let Err(err) = socket.set_mark(mark)
+        {
+            warn!("failed to set SO_MARK {} on udp socket: {:?}", mark, err);
         }
         #[cfg(not(any(target_os = "linux", target_os = "android")))]
         let _ = mark;


### PR DESCRIPTION
Adds an optional fwmark to netwatch's UDP socket so a caller can policy-route the socket's own egress, for example around a full-tunnel default route so the tunnel does not swallow the packets carrying it.

## What

- New public `UdpSocket::bind_full_with_mark(addr, Option<u32>)`. Existing `bind_full` and the other `bind_*` entrypoints are unchanged (they pass `None`).
- The mark threads through `bind_raw` into `SocketState::bind` and is stored in both `SocketState` variants, so it is reapplied on every rebind.
- Applied via `socket2`'s `set_mark` under `cfg(any(target_os = "linux", target_os = "android"))`; a no-op on other platforms.

## Why

I'm building a full-tunnel client on top of iroh where the endpoint's own underlay UDP packets must skip a `0.0.0.0/0` default route (the standard WireGuard/Tailscale SO_MARK + `ip rule` approach). netwatch owns the socket and today exposes no way to set a socket option, so this adds a minimal, opt-in hook. `None` preserves current behaviour exactly.

Happy to adjust the API shape (e.g. a builder-style option) if you'd prefer.