### PR TITLE
examples: add monitor_and_probe example for netwatch and portmapper integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,6 +1526,7 @@ dependencies = [
  "libc",
  "n0-error",
  "n0-future",
+ "n0-watcher",
  "netwatch",
  "ntest",
  "num_enum",

--- a/portmapper/Cargo.toml
+++ b/portmapper/Cargo.toml
@@ -43,7 +43,8 @@ tower-layer = "0.3.3"
 [dev-dependencies]
 ntest = "0.9"
 rand_chacha = "0.10"
-tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "macros", "time", "test-util"] }
+tokio = { version = "1", features = ["io-util", "sync", "rt", "net", "fs", "macros", "time", "test-util", "rt-multi-thread"] }
+n0-watcher = "1.0.0"
 
 [features]
 default = ["metrics"]

--- a/portmapper/examples/monitor_and_probe.rs
+++ b/portmapper/examples/monitor_and_probe.rs
@@ -30,15 +30,13 @@ async fn main() -> Result<()> {
                 should_probe = false;
 
                 let Some(state) = state else {
+                    // Stream has ended due to underlying actor shutting down
                     break;
                 };
 
                 // Skip if no default route is currently active
-                let default_route_interface_name = match state.default_route_interface {
-                    Some(i) => i,
-                    None => {
-                        continue;
-                    }
+                let Some(default_route_interface_name) = state.default_route_interface else {
+                    continue;
                 };
 
                 if let Some(default_route_interface) = state.interfaces.get(&default_route_interface_name) {

--- a/portmapper/examples/monitor_and_probe.rs
+++ b/portmapper/examples/monitor_and_probe.rs
@@ -1,0 +1,58 @@
+//! //! Monitor network changes and probe the default route interface for port mapping support.
+//!
+//! This example demonstrates how to use `netwatch` and `portmapper` to:
+//! - Monitor network interface state changes
+//! - Detect the current default route interface
+//! - Probe for port mapping protocol support (NAT-PMP, PCP, UPnP)
+
+use n0_error::Result;
+use n0_future::StreamExt;
+use n0_watcher::{self, Watcher};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!("\nprobe example!\n");
+
+    let monitor = netwatch::netmon::Monitor::new()
+        .await
+        .expect("failed to create netmon::Monitor");
+
+    let mut stream = monitor.interface_state().stream_updates_only();
+    let pm = portmapper::Client::new(portmapper::Config::default());
+
+    // Monitor for network interface state changes
+    while let Some(state) = stream.next().await {
+        // Skip if no default route is currently active
+        let default_route_interface_name = match state.default_route_interface {
+            Some(i) => i,
+            None => continue,
+        };
+
+        if let Some(default_route_interface) = state.interfaces.get(&default_route_interface_name) {
+            println!(
+                "\ndefault route interface: {}",
+                default_route_interface.name()
+            );
+            // Display the current network addresses for this interface
+            default_route_interface.addrs().for_each(|addr| {
+                match addr {
+                    netwatch::interfaces::IpNet::V4(ipv4_net) => println!("\tipv4: {}", ipv4_net),
+                    netwatch::interfaces::IpNet::V6 { net, .. } => println!("\tipv6: {}", net),
+                };
+            });
+            print!("\n\tport mapping: ");
+            // Probe the current interface for port mapping protocol support
+            match pm.probe().await {
+                Ok(Ok(res)) => {
+                    match (res.nat_pmp, res.pcp, res.upnp) {
+                        (false, false, false) => println!("none"),
+                        _ => println!("{:?}", res),
+                    };
+                }
+                Ok(Err(e)) => eprintln!("portmapper probe error: {e}"),
+                Err(e) => eprintln!("recv error: {e}"),
+            };
+        }
+    }
+    Ok(())
+}

--- a/portmapper/examples/monitor_and_probe.rs
+++ b/portmapper/examples/monitor_and_probe.rs
@@ -1,4 +1,4 @@
-//! //! Monitor network changes and probe the default route interface for port mapping support.
+//! Monitor network changes and probe the default route interface for port mapping support.
 //!
 //! This example demonstrates how to use `netwatch` and `portmapper` to:
 //! - Monitor network interface state changes
@@ -20,38 +20,56 @@ async fn main() -> Result<()> {
     let mut stream = monitor.interface_state().stream_updates_only();
     let pm = portmapper::Client::new(portmapper::Config::default());
 
-    // Monitor for network interface state changes
-    while let Some(state) = stream.next().await {
-        // Skip if no default route is currently active
-        let default_route_interface_name = match state.default_route_interface {
-            Some(i) => i,
-            None => continue,
-        };
+    let mut should_probe = false;
 
-        if let Some(default_route_interface) = state.interfaces.get(&default_route_interface_name) {
-            println!(
-                "\ndefault route interface: {}",
-                default_route_interface.name()
-            );
-            // Display the current network addresses for this interface
-            default_route_interface.addrs().for_each(|addr| {
-                match addr {
-                    netwatch::interfaces::IpNet::V4(ipv4_net) => println!("\tipv4: {}", ipv4_net),
-                    netwatch::interfaces::IpNet::V6 { net, .. } => println!("\tipv6: {}", net),
+    loop {
+        tokio::select! {
+            biased;
+            // Monitor for network interface state changes
+            state = stream.next() => {
+                should_probe = false;
+
+                let Some(state) = state else {
+                    break;
                 };
-            });
-            print!("\n\tport mapping: ");
-            // Probe the current interface for port mapping protocol support
-            match pm.probe().await {
-                Ok(Ok(res)) => {
-                    match (res.nat_pmp, res.pcp, res.upnp) {
-                        (false, false, false) => println!("none"),
-                        _ => println!("{:?}", res),
-                    };
+
+                // Skip if no default route is currently active
+                let default_route_interface_name = match state.default_route_interface {
+                    Some(i) => i,
+                    None => {
+                        continue;
+                    }
+                };
+
+                if let Some(default_route_interface) = state.interfaces.get(&default_route_interface_name) {
+                    println!(
+                        "\ndefault route interface: {}",
+                        default_route_interface.name()
+                    );
+                    // Display the current network addresses for this interface
+                    default_route_interface.addrs().for_each(|addr| {
+                        match addr {
+                            netwatch::interfaces::IpNet::V4(ipv4_net) => println!("\tipv4: {}", ipv4_net),
+                            netwatch::interfaces::IpNet::V6 { net, .. } => println!("\tipv6: {}", net),
+                        };
+                    });
+                    should_probe = true;
                 }
-                Ok(Err(e)) => eprintln!("portmapper probe error: {e}"),
-                Err(e) => eprintln!("recv error: {e}"),
-            };
+            },
+            // Probe the current default route interface for port mapping protocol support
+            res = pm.probe(), if should_probe => {
+                should_probe = false;
+                print!("port mapping: ");
+                match res {
+                    Ok(Ok(res)) => {
+                        match (res.nat_pmp, res.pcp, res.upnp) {
+                            (false, false, false) => println!("none"),
+                            _ => println!("{:?}", res),
+                        }},
+                    Ok(Err(e)) => eprintln!("portmapper probe error: {e}"),
+                    Err(e) => eprintln!("recv error: {e}"),
+                }
+            },
         }
     }
     Ok(())


### PR DESCRIPTION
## Description
Add a new example demonstrating integration of netwatch and portmapper for monitoring network changes and probing port mapping support on the default route interface.

## Breaking Changes
None
## Notes & open questions
None
## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented. (None)