### PR TITLE
fix(netwatch): ignore RTM_MISS in the BSD route monitor

### DIFF
--- a/netwatch/src/netmon/bsd.rs
+++ b/netwatch/src/netmon/bsd.rs
@@ -169,6 +169,30 @@ pub(super) fn is_interesting_message(msg: &WireMessage) -> bool {
             true
         }
         WireMessage::Route(msg) => {
+            // RTM_MISS reports the fate of a packet, not a change to the
+            // routing table: a lookup found no route for a destination. The
+            // table is identical before and after, so rebuilding the interface
+            // state can only conclude that nothing changed — and on macOS that
+            // rebuild is a full `getifaddrs` sweep (once per address, since
+            // `if_nametoindex` calls it again) plus a synchronous CoreWLAN XPC
+            // round-trip per Wi-Fi interface.
+            //
+            // A host with no working IPv6 route emits these continuously: every
+            // application's failed v6 connect produces one, and they are
+            // broadcast to every AF_ROUTE listener on the machine, so processes
+            // pay for traffic they had no part in. Measured on a laptop whose v6
+            // default sat behind a VPN tunnel, 1138 of 1142 route messages over
+            // two minutes were RTM_MISS, driving ~1.15 interface enumerations
+            // per second in each idle process — every one of which then logged
+            // "no changes detected".
+            //
+            // Real topology changes still arrive as RTM_ADD/RTM_DELETE/
+            // RTM_CHANGE, or as the RTM_NEWADDR/RTM_DELADDR/RTM_IFINFO handled
+            // above, so dropping this loses no signal.
+            if msg.r#type as libc::c_int == libc::RTM_MISS {
+                return false;
+            }
+
             // Ignore local unicast
             if let Some(addr) = msg.addrs.get(RTAX_DST as usize)
                 && let Some(ip) = addr.ip()

--- a/netwatch/src/netmon/bsd.rs
+++ b/netwatch/src/netmon/bsd.rs
@@ -169,6 +169,12 @@ pub(super) fn is_interesting_message(msg: &WireMessage) -> bool {
             true
         }
         WireMessage::Route(msg) => {
+            // RTM_MISS is not a route change and can be emitted often on
+            // dual-stack hosts with no IPv6 connectivity.
+            if msg.r#type as libc::c_int == libc::RTM_MISS {
+                return false;
+            }
+
             // Ignore local unicast
             if let Some(addr) = msg.addrs.get(RTAX_DST as usize)
                 && let Some(ip) = addr.ip()


### PR DESCRIPTION
## Summary

`is_interesting_message` treats every non-link-local `Route` message as a topology change and schedules a debounced interface re-enumeration (`State::new()`). `RTM_MISS` is registered as a `Route` message but reports the fate of a *packet* (a route lookup found nothing), not a change to the routing table — the table is identical before and after, so the rebuild can only ever conclude nothing changed.

On macOS that rebuild is a full `getifaddrs` sweep (once per address, since `if_nametoindex` calls it again internally) plus a synchronous CoreWLAN XPC round-trip per Wi-Fi interface. A host with no working IPv6 route emits `RTM_MISS` continuously — every application's failed v6 connect produces one — and the kernel broadcasts it to every `AF_ROUTE` listener on the machine, so every process pays for traffic it had no part in.

This adds an early return for `RTM_MISS` in the `WireMessage::Route` arm, ahead of the existing link-local check. Real topology changes are unaffected: they still arrive as `RTM_ADD`/`RTM_DELETE`/`RTM_CHANGE`, or as `RTM_NEWADDR`/`RTM_DELADDR`/`RTM_IFINFO` handled elsewhere in the same function.

## Measurements

macOS 27, aarch64, 30 interfaces / 23 addresses, IPv6 default route behind a VPN tunnel:

- Route capture, 120s: 1142 messages, 1138 were `RTM_MISS`. Second capture, 180s: 904 of 904. The only non-MISS traffic was a handful of `RTM_ADD`.
- Symbolized profile of an idle process: `netwatch::netmon::Monitor::new::{{closure}}` = 61% of all non-parked time, under it `netdev`'s interface enumeration and Wi-Fi transmit-rate lookup (9.4% of monitor cost).
- 100% of enumerations (276 of 276) logged `"no changes detected"`.
- `divan` bench of a single `netwatch::interfaces::State::new()`: 7.85ms mean on this host.
- Paired A/B (patched and unpatched binaries running simultaneously against one identical 904-message route stream, since idle CPU here swings ~1.6x hour to hour with ambient churn):
  - baseline: 3.62s CPU over 180s (2.01% of one core), 226 enumerations
  - patched: 0.10s CPU over 180s (0.06% of one core), 0 enumerations
  - 97.2% less idle CPU, 36.2x

## Scope and caveats

- macOS/BSD only — Linux's `netmon` uses netlink, which has no `RTM_MISS` analogue.
- The 36.2x figure is specific to this host's network setup (IPv6 default route behind a VPN, which manufactures the miss storm); a clean network will see fewer misses and a smaller absolute win. The reasoning (an `RTM_MISS` is never a topology change) holds regardless of the multiplier.
- `RTM_LOSING`/`RTM_REDIRECT` are the same category by reasoning but were not observed in any capture, so they're left unfiltered here rather than made on unmeasured claims — possible follow-up.
- Not in this PR: `State::new()` currently calls `get_interfaces()` twice (once directly, once via `default_route_interface()`), measured at 3.72ms of the 7.85ms total. Worth its own change.

## Test plan

- [x] `cargo test -p netwatch` passes
- [x] Paired A/B capture shows real topology events (`RTM_ADD`) still trigger enumeration; `RTM_MISS` no longer does