### PR TITLE
ci(secruity): hardening + lock files + dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       github-actions:
         patterns:
           - "*"  # Group all Actions updates into a single larger pull request
+    # Let a compromised publish be noticed before we propose it. Applies to
+    # version updates only -- security updates ignore the cooldown.
+    cooldown:
+      default-days: 7
     schedule:
       interval: weekly
       day: "thursday"
@@ -16,6 +20,8 @@ updates:
       timezone: "America/New_York"
   - package-ecosystem: cargo
     directory: /
+    cooldown:
+      default-days: 7
     schedule:
       interval: weekly
       day: "thursday"
@@ -23,6 +29,8 @@ updates:
       timezone: "America/New_York"
   - package-ecosystem: docker
     directory: docker
+    cooldown:
+      default-days: 7
     schedule:
       interval: weekly
       day: "thursday"

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -15,6 +15,10 @@ concurrency:
 env:
   IROH_FORCE_STAGING_RELAYS: "1"
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   tests:
     uses: './.github/workflows/tests.yaml'

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -30,9 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Extract test results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          printf '${{ toJSON(needs) }}\n'
-          result=$(echo '${{ toJSON(needs) }}' | jq -r .tests.result)
+          printf '%s\n' "$NEEDS_JSON"
+          result=$(echo "$NEEDS_JSON" | jq -r .tests.result)
           echo TESTS_RESULT=$result
           echo "TESTS_RESULT=$result" >>"$GITHUB_ENV"
       - name: Notify discord on failure

--- a/.github/workflows/beta.yaml
+++ b/.github/workflows/beta.yaml
@@ -32,7 +32,7 @@ jobs:
           echo TESTS_RESULT=$result
           echo "TESTS_RESULT=$result" >>"$GITHUB_ENV"
       - name: Notify discord on failure
-        uses: n0-computer/discord-webhook-notify@v1
+        uses: n0-computer/discord-webhook-notify@1399c1b2d57cc05894d506d2cfdc33c5f012b993 # v1.1.1
         if: ${{ env.TESTS_RESULT == 'failure' }}
         with:
           text: "Beta tests in **${ github.repository }** failed:"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
+        persist-credentials: false
         submodules: recursive
 
     - name: Install rust stable
@@ -94,6 +95,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
@@ -142,6 +145,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
+        persist-credentials: false
         submodules: recursive
 
     - name: Install rust stable
@@ -174,6 +178,8 @@ jobs:
       SCCACHE_GHA_ENABLED: "on"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       # Pinned: nightly-2026-07-30 and later fail to build std for espidf
       # (libc::AT_FDCWD missing, see https://github.com/rust-lang/rust/pull/158168).
       # Unpin once fixed upstream.
@@ -191,6 +197,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
@@ -229,6 +237,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Install sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
@@ -260,6 +269,8 @@ jobs:
       SCCACHE_GHA_ENABLED: "on"
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
         toolchain: stable
@@ -282,6 +293,8 @@ jobs:
       SCCACHE_GHA_ENABLED: "on"
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
         toolchain: nightly-2026-04-17
@@ -301,6 +314,8 @@ jobs:
       SCCACHE_GHA_ENABLED: "on"
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
         toolchain: stable
@@ -338,6 +353,8 @@ jobs:
       TOOLCHAIN: "nightly-2026-03-20"
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
         toolchain: ${{ env.TOOLCHAIN }}
@@ -365,6 +382,8 @@ jobs:
       SCCACHE_GHA_ENABLED: "on"
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
         toolchain: ${{ env.MSRV }}
@@ -381,6 +400,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           arguments: --workspace --all-features
@@ -392,5 +413,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - run: pip install --user codespell[toml]
     - run: codespell --ignore-words-list=ans,atmost,crate,inout,ratatui,ser,stayin,swarmin,worl --skip=CHANGELOG.md

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,10 @@ env:
   SCCACHE_CACHE_SIZE: "10G"
   IROH_FORCE_STAGING_RELAYS: "1"
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: CI Test Suite

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,8 +119,8 @@ jobs:
       env:
         ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
       run: |
-        cargo install --version 3.5.4 cargo-ndk
-        cargo ndk --target ${{ matrix.target }} build
+        cargo install --locked --version 3.5.4 cargo-ndk
+        cargo ndk --target ${{ matrix.target }} build --locked
 
   cross_test:
     name: Cross Test
@@ -179,7 +179,7 @@ jobs:
           components: rust-src
       - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Check workspace for ESP32-C3
-        run: cargo check -Z build-std=std,panic_abort --target riscv32imc-esp-espidf --workspace --no-default-features
+        run: cargo check --locked -Z build-std=std,panic_abort --target riscv32imc-esp-espidf --workspace --no-default-features
 
   wasm_test:
     name: Build & test wasm32 for browsers
@@ -206,7 +206,7 @@ jobs:
         uses: bytecodealliance/actions/wasm-tools/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3
 
       - name: wasm32 build (netwatch)
-        run: cargo build --target wasm32-unknown-unknown -p netwatch
+        run: cargo build --locked --target wasm32-unknown-unknown -p netwatch
 
       # If the Wasm file contains any 'import "env"' declarations, then
       # some non-Wasm-compatible code made it into the final code.
@@ -215,7 +215,7 @@ jobs:
           ! wasm-tools print --skeleton target/wasm32-unknown-unknown/debug/netwatch.wasm | grep 'import "env"'
 
       - name: Run smoke test in wasm
-        run: cargo test -p netwatch --test smoke --target=wasm32-unknown-unknown
+        run: cargo test --locked -p netwatch --test smoke --target=wasm32-unknown-unknown
 
   check_semver:
     runs-on: ubuntu-latest
@@ -265,6 +265,9 @@ jobs:
       with:
         tool: cargo-make
     - run: cargo make format-check
+    - name: Lockfile must not have moved
+      # cargo make takes no --locked; assert the lockfile instead.
+      run: git diff --exit-code Cargo.lock
 
   check_docs:
     timeout-minutes: 30
@@ -282,7 +285,7 @@ jobs:
       uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
     - name: Docs
-      run: cargo doc --workspace --all-features --no-deps --document-private-items
+      run: cargo doc --locked --workspace --all-features --no-deps --document-private-items
       env:
         RUSTDOCFLAGS: --cfg docsrs
 
@@ -304,13 +307,13 @@ jobs:
     # TODO: We have a bunch of platform-dependent code so should
     #    probably run this job on the full platform matrix
     - name: clippy check (all features)
-      run: cargo clippy --workspace --all-features --all-targets --bins --tests --benches
+      run: cargo clippy --locked --workspace --all-features --all-targets --bins --tests --benches
 
     - name: clippy check (no features)
-      run: cargo clippy --workspace --no-default-features --lib --bins --tests
+      run: cargo clippy --locked --workspace --no-default-features --lib --bins --tests
 
     - name: clippy check (default features)
-      run: cargo clippy --workspace --all-targets
+      run: cargo clippy --locked --workspace --all-targets
 
   external_types:
     timeout-minutes: 30
@@ -344,6 +347,9 @@ jobs:
           cargo-check-external-types@${{ env.CARGO_CHECK_EXTERNAL_TYPES_VERSION }}
     - name: Check external types
       run: cargo make check-external-types
+    - name: Lockfile must not have moved
+      # cargo make takes no --locked; assert the lockfile instead.
+      run: git diff --exit-code Cargo.lock
 
   msrv:
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"
@@ -363,7 +369,7 @@ jobs:
 
     - name: Check MSRV all features
       run: |
-        cargo +$MSRV check --workspace --all-targets
+        cargo +$MSRV check --locked --workspace --all-targets
 
   cargo_deny:
     timeout-minutes: 30

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,8 +76,9 @@ jobs:
       # cross tests are currently broken vor armv7 and aarch64
       # see https://github.com/cross-rs/cross/issues/1311.  So on
       # those platforms we only build but do not run tests.
-      run: cross build --all --target ${{ matrix.target }}
+      run: cross build --all --target $RUST_TARGET
       env:
+        RUST_TARGET: ${{ matrix.target }}
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
 
   android_build:
@@ -104,7 +105,9 @@ jobs:
         toolchain: stable
         target: ${{ matrix.target }}
     - name: Install rustup target
-      run: rustup target add ${{ matrix.target }}
+      env:
+        RUST_TARGET: ${{ matrix.target }}
+      run: rustup target add $RUST_TARGET
 
     - name: Setup Java
       uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
@@ -124,10 +127,11 @@ jobs:
 
     - name: Build
       env:
+        RUST_TARGET: ${{ matrix.target }}
         ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
       run: |
         cargo install --locked --version 3.5.4 cargo-ndk
-        cargo ndk --target ${{ matrix.target }} build --locked
+        cargo ndk --target $RUST_TARGET build --locked
 
   cross_test:
     name: Cross Test
@@ -164,8 +168,9 @@ jobs:
         tool: cross
 
     - name: test
-      run: cross test --all --target ${{ matrix.target }} -- --test-threads=12
+      run: cross test --all --target $RUST_TARGET -- --test-threads=12
       env:
+        RUST_TARGET: ${{ matrix.target }}
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG' }}
 
   esp32_check:
@@ -246,7 +251,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         shell: bash
         run: |
-          echo "HEAD_COMMIT_SHA=$(git rev-parse origin/${{ github.base_ref }})" >> ${GITHUB_ENV}
+          echo "HEAD_COMMIT_SHA=$(git rev-parse origin/$GITHUB_BASE_REF)" >> ${GITHUB_ENV}
       - name: Setup Environment (Push)
         if: ${{ github.event_name == 'push' || github.event_name == 'merge_group' }}
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,12 +48,14 @@ jobs:
           # - x86_64-unknown-netbsd
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
 
     - name: Install rust stable
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+      with:
+        toolchain: stable
 
     - name: Cleanup Docker
       continue-on-error: true
@@ -61,7 +63,9 @@ jobs:
         docker kill $(docker ps -q)
 
       # See https://github.com/cross-rs/cross/issues/1222
-    - uses: taiki-e/install-action@cross
+    - uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
+      with:
+        tool: cross
 
     - name: build
       # cross tests are currently broken vor armv7 and aarch64
@@ -85,26 +89,27 @@ jobs:
           - armv7-linux-androideabi
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
+        toolchain: stable
         target: ${{ matrix.target }}
     - name: Install rustup target
       run: rustup target add ${{ matrix.target }}
 
     - name: Setup Java
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         distribution: 'temurin'
         java-version: '17'
 
     - name: Setup Android SDK
-      uses: android-actions/setup-android@v4
+      uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
     - name: Setup Android NDK
-      uses: arqu/setup-ndk@main
+      uses: arqu/setup-ndk@4f8a02c22e2c17ff9ebba9026e599da847aa8374 # main
       id: setup-ndk
       with:
         ndk-version: r23
@@ -131,12 +136,14 @@ jobs:
           - i686-unknown-linux-gnu
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
 
     - name: Install rust stable
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+      with:
+        toolchain: stable
 
     - name: Cleanup Docker
       continue-on-error: true
@@ -144,7 +151,9 @@ jobs:
         docker kill $(docker ps -q)
 
       # See https://github.com/cross-rs/cross/issues/1222
-    - uses: taiki-e/install-action@cross
+    - uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
+      with:
+        tool: cross
 
     - name: test
       run: cross test --all --target ${{ matrix.target }} -- --test-threads=12
@@ -160,15 +169,15 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Pinned: nightly-2026-07-30 and later fail to build std for espidf
       # (libc::AT_FDCWD missing, see https://github.com/rust-lang/rust/pull/158168).
       # Unpin once fixed upstream.
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly-2026-07-29
           components: rust-src
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Check workspace for ESP32-C3
         run: cargo check -Z build-std=std,panic_abort --target riscv32imc-esp-espidf --workspace --no-default-features
 
@@ -177,22 +186,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
 
       - name: Add wasm target
         run: rustup target add wasm32-unknown-unknown
 
       - name: Install wasm-bindgen-test-runner
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
         with:
           # Match the version of wasm-bindgen used in Cargo.lock
           tool: wasm-bindgen-cli@0.2.122
 
       - name: Install wasm-tools
-        uses: bytecodealliance/actions/wasm-tools/setup@v1
+        uses: bytecodealliance/actions/wasm-tools/setup@9152e710e9f7182e4c29ad218e4f335a7b203613 # v1.1.3
 
       - name: wasm32 build (netwatch)
         run: cargo build --target wasm32-unknown-unknown -p netwatch
@@ -212,11 +223,11 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Install sccache
-        uses: mozilla-actions/sccache-action@v0.0.11
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
       - name: Setup Environment (PR)
         if: ${{ github.event_name == 'pull_request' }}
@@ -230,7 +241,7 @@ jobs:
           echo "HEAD_COMMIT_SHA=$(git rev-parse origin/main)" >> ${GITHUB_ENV}
       - name: Check semver
         # uses: obi1kenobi/cargo-semver-checks-action@v2
-        uses: n0-computer/cargo-semver-checks-action@feat-baseline
+        uses: n0-computer/cargo-semver-checks-action@b49de9133f8849bb51cae32c6bdeb19a5c37e61f # feat-baseline
         with:
           package: portmapper, netwatch
           baseline-rev: ${{ env.HEAD_COMMIT_SHA }}
@@ -244,12 +255,15 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-    - uses: actions/checkout@v7
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
+        toolchain: stable
         components: rustfmt
-    - uses: mozilla-actions/sccache-action@v0.0.11
-    - uses: taiki-e/install-action@cargo-make
+    - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+    - uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
+      with:
+        tool: cargo-make
     - run: cargo make format-check
 
   check_docs:
@@ -260,12 +274,12 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-    - uses: actions/checkout@v7
-    - uses: dtolnay/rust-toolchain@master
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
         toolchain: nightly-2026-04-17
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.11
+      uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
     - name: Docs
       run: cargo doc --workspace --all-features --no-deps --document-private-items
@@ -279,12 +293,13 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-    - uses: actions/checkout@v7
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
+        toolchain: stable
         components: clippy
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.11
+      uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
     # TODO: We have a bunch of platform-dependent code so should
     #    probably run this job on the full platform matrix
@@ -315,14 +330,14 @@ jobs:
       CARGO_CHECK_EXTERNAL_TYPES_VERSION: "0.5.0"
       TOOLCHAIN: "nightly-2026-03-20"
     steps:
-    - uses: actions/checkout@v7
-    - uses: dtolnay/rust-toolchain@master
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
         toolchain: ${{ env.TOOLCHAIN }}
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.11
+      uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
     - name: Install cargo-make and cargo-check-external-types
-      uses: taiki-e/install-action@v2
+      uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
       with:
         tool: |
           cargo-make
@@ -339,12 +354,12 @@ jobs:
       RUSTC_WRAPPER: "sccache"
       SCCACHE_GHA_ENABLED: "on"
     steps:
-    - uses: actions/checkout@v7
-    - uses: dtolnay/rust-toolchain@master
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
         toolchain: ${{ env.MSRV }}
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.11
+      uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
     - name: Check MSRV all features
       run: |
@@ -355,8 +370,8 @@ jobs:
     name: cargo deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           arguments: --workspace --all-features
           command: check
@@ -366,6 +381,6 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - run: pip install --user codespell[toml]
     - run: codespell --ignore-words-list=ans,atmost,crate,inout,ratatui,ser,stayin,swarmin,worl --skip=CHANGELOG.md

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: generated-docs-preview
+          # stays on: this job prunes the branch with a bare `git push`
+          persist-credentials: true
       - name: Clean docs branch
         run: |
           git config user.name "github-actions[bot]"

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -15,11 +15,14 @@ concurrency:
 env:
   IROH_FORCE_STAGING_RELAYS: "1"
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   clean_docs_branch:
     permissions:
-      issues: write
-      contents: write
+      contents: write        # this job prunes the preview branch with a push
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: generated-docs-preview
       - name: Clean docs branch

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -14,6 +14,6 @@ jobs:
     steps:
       - name: check-for-cc
         id: check-for-cc
-        uses: agenthunt/conventional-commit-checker-action@v2.0.1
+        uses: agenthunt/conventional-commit-checker-action@f1823f632e95a64547566dcd2c7da920e67117ad # v2.0.1
         with:
           pr-title-regex: "^(.+)(?:(([^)s]+)))?!?: (.+)"

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -8,6 +8,10 @@ on:
 env:
   IROH_FORCE_STAGING_RELAYS: "1"
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   check-for-cc:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,9 +15,15 @@ concurrency:
 env:
   IROH_FORCE_STAGING_RELAYS: "1"
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   preview_docs:
-    permissions: write-all
+    permissions:
+      contents: write        # actions-gh-pages pushes the preview branch
+      pull-requests: write   # find-comment / create-or-update-comment
     timeout-minutes: 30
     name: Docs preview
     if: ${{ (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' ) && !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -37,7 +37,7 @@ jobs:
       uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
     - name: Generate Docs
-      run: cargo doc --workspace --all-features --no-deps
+      run: cargo doc --locked --workspace --all-features --no-deps
       env:
         RUSTDOCFLAGS: --cfg iroh_docsrs
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -36,6 +36,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
         toolchain: nightly-2025-10-09

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -29,12 +29,12 @@ jobs:
       PREVIEW_PATH: pr/${{ github.event.pull_request.number || inputs.pr_number }}/docs
 
     steps:
-    - uses: actions/checkout@v7
-    - uses: dtolnay/rust-toolchain@master
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+    - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
         toolchain: nightly-2025-10-09
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.11
+      uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
     - name: Generate Docs
       run: cargo doc --workspace --all-features --no-deps
@@ -42,7 +42,7 @@ jobs:
         RUSTDOCFLAGS: --cfg iroh_docsrs
 
     - name: Deploy Docs to Preview Branch
-      uses: peaceiris/actions-gh-pages@v4
+      uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./target/doc/
@@ -50,7 +50,7 @@ jobs:
         publish_branch: generated-docs-preview
 
     - name: Find Docs Comment
-      uses: peter-evans/find-comment@v4
+      uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
       id: fc
       with:
         issue-number: ${{ github.event.pull_request.number || inputs.pr_number }}
@@ -62,7 +62,7 @@ jobs:
       run: echo "TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
 
     - name: Create or Update Docs Comment
-      uses: peter-evans/create-or-update-comment@v5
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
       with:
         issue-number: ${{ github.event.pull_request.number || inputs.pr_number }}
         comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -40,6 +40,10 @@ concurrency:
 env:
   IROH_FORCE_STAGING_RELAYS: "1"
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   tests:
     if: "contains(github.event.pull_request.labels.*.name, 'flaky-test') || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'"

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -59,7 +59,7 @@ jobs:
           echo TESTS_RESULT=$result
           echo "TESTS_RESULT=$result" >>"$GITHUB_ENV"
       - name: download nextest reports
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-*
           merge-multiple: true
@@ -90,7 +90,7 @@ jobs:
           echo "See https://github.com/${{ github.repository }}/actions/workflows/flaky.yaml" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
       - name: Notify discord on failure
-        uses: n0-computer/discord-webhook-notify@v1
+        uses: n0-computer/discord-webhook-notify@1399c1b2d57cc05894d506d2cfdc33c5f012b993 # v1.1.1
         if: ${{ env.TESTS_RESULT == 'failure' || env.TESTS_RESULT == 'success' }}
         with:
           text: "Flaky tests in **${{ github.repository }}**:"

--- a/.github/workflows/flaky.yaml
+++ b/.github/workflows/flaky.yaml
@@ -57,9 +57,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Extract test results
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
         run: |
-          printf '${{ toJSON(needs) }}\n'
-          result=$(echo '${{ toJSON(needs) }}' | jq -r .tests.result)
+          printf '%s\n' "$NEEDS_JSON"
+          result=$(echo "$NEEDS_JSON" | jq -r .tests.result)
           echo TESTS_RESULT=$result
           echo "TESTS_RESULT=$result" >>"$GITHUB_ENV"
       - name: download nextest reports
@@ -91,7 +93,7 @@ jobs:
             echo "$failure" >> $GITHUB_OUTPUT
           done
           echo "" >> $GITHUB_OUTPUT
-          echo "See https://github.com/${{ github.repository }}/actions/workflows/flaky.yaml" >> $GITHUB_OUTPUT
+          echo "See https://github.com/$GITHUB_REPOSITORY/actions/workflows/flaky.yaml" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
       - name: Notify discord on failure
         uses: n0-computer/discord-webhook-notify@1399c1b2d57cc05894d506d2cfdc33c5f012b993 # v1.1.1

--- a/.github/workflows/patchbay.yml
+++ b/.github/workflows/patchbay.yml
@@ -27,11 +27,13 @@ jobs:
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
         continue-on-error: true
 
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.11
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Install cargo-make and cargo-nextest
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
         with:
           tool: nextest@0.9.80,cargo-make
 
@@ -48,7 +50,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: patchbay-testdir-${{ github.sha }}
           path: |

--- a/.github/workflows/patchbay.yml
+++ b/.github/workflows/patchbay.yml
@@ -15,6 +15,10 @@ env:
   RUST_BACKTRACE: 1
   SCCACHE_CACHE_SIZE: "10G"
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   patchbay_tests:
     name: Patchbay Tests

--- a/.github/workflows/patchbay.yml
+++ b/.github/workflows/patchbay.yml
@@ -32,6 +32,8 @@ jobs:
         continue-on-error: true
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable

--- a/.github/workflows/patchbay.yml
+++ b/.github/workflows/patchbay.yml
@@ -48,6 +48,9 @@ jobs:
           PATCHBAY_LOG: trace
           RUST_LOG: trace
 
+      - name: Lockfile must not have moved
+        # cargo make takes no --locked; assert the lockfile instead.
+        run: git diff --exit-code Cargo.lock
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -98,26 +98,26 @@ jobs:
           else
             targets="--lib --bins"
           fi
-          echo cargo check -p $i $FEATURES $targets
-          cargo check -p $i $FEATURES $targets
+          echo cargo check --locked -p $i $FEATURES $targets
+          cargo check --locked -p $i $FEATURES $targets
         done
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
 
     - name: build tests
       run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
+        cargo nextest run --locked --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
 
     - name: list ignored tests
       run: |
-        cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ignored-only
+        cargo nextest list --locked --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ignored-only
       env:
         NEXTEST_NO_TESTS: "pass"
 
     - name: run tests
       run: |
         mkdir -p output
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        cargo nextest run --locked --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
@@ -140,7 +140,7 @@ jobs:
         else
             export RUST_LOG=DEBUG
         fi
-        cargo test --workspace --all-features --doc
+        cargo test --locked --workspace --all-features --doc
 
   build_and_test_windows:
     timeout-minutes: 30
@@ -208,18 +208,18 @@ jobs:
 
     - name: build tests
       run: |
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
+        cargo nextest run --locked --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
 
     - name: list ignored tests
       run: |
-        cargo nextest list --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
+        cargo nextest list --locked --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
       env:
         NEXTEST_NO_TESTS: "pass"
 
     - name: tests
       run: |
         mkdir -p output
-        cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
+        cargo nextest run --locked --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
@@ -256,6 +256,10 @@ jobs:
         with:
           toolchain: nightly
       - name: cargo check
+        # No --locked: re-resolving is the point, so -Z min-publish-age guards
+        # the versions the lockfile has never seen.
         run: |
           rm -f Cargo.lock
-          cargo +nightly check -Z minimal-versions --workspace --all-features --lib --bins
+          cargo +nightly check -Z minimal-versions -Z min-publish-age \
+            --config 'registry.global-min-publish-age="3 days"' \
+            --workspace --all-features --lib --bins

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -256,7 +256,11 @@ jobs:
         retention-days: 1
         compression-level: 0
   minimal-crates:
+    # Ephemeral only: this job resolves versions the lockfile has never seen
+    # and runs their build scripts.
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -266,12 +270,12 @@ jobs:
             os: ubuntu-latest
             release-os: linux
             release-arch: amd64
-            runner: [self-hosted, linux, X64]
+            runner: ubuntu-latest
           - name: macOS-arm-latest
             os: macOS-latest
             release-os: darwin
             release-arch: aarch64
-            runner: [self-hosted, macOS, ARM64]
+            runner: macos-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -111,22 +111,25 @@ jobs:
 
     - name: build tests
       run: |
-        cargo nextest run --locked --workspace ${{ env.FEATURES }} --lib --bins --tests --no-run
+        cargo nextest run --locked --workspace $FEATURES --lib --bins --tests --no-run
 
     - name: list ignored tests
       run: |
-        cargo nextest list --locked --workspace ${{ env.FEATURES }} --lib --bins --tests --run-ignored ignored-only
+        cargo nextest list --locked --workspace $FEATURES --lib --bins --tests --run-ignored ignored-only
       env:
         NEXTEST_NO_TESTS: "pass"
 
     - name: run tests
-      run: |
-        mkdir -p output
-        cargo nextest run --locked --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
         NEXTEST_NO_TESTS: "pass"
+        RUN_IGNORED: ${{ inputs.flaky && 'all' || 'default' }}
+        MSG_FORMAT: ${{ inputs.flaky && 'libtest-json' || 'human' }}
+        OUT_NAME: ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}
+      run: |
+        mkdir -p output
+        cargo nextest run --locked --workspace $FEATURES --lib --bins --tests --profile ci --run-ignored "$RUN_IGNORED" --no-fail-fast --message-format "$MSG_FORMAT" > "output/$OUT_NAME.json"
 
     - name: upload results
       if: ${{ failure() && inputs.flaky }}
@@ -175,11 +178,14 @@ jobs:
         ref: ${{ inputs.git-ref }}
 
     - name: Install ${{ matrix.rust }}
+      env:
+        RUST_TOOLCHAIN: ${{ matrix.rust }}
+        RUST_TARGET: ${{ matrix.target }}
       run: |
-        rustup toolchain install ${{ matrix.rust }}
-        rustup toolchain default ${{ matrix.rust }}
-        rustup target add ${{ matrix.target }}
-        rustup set default-host ${{ matrix.target }}
+        rustup toolchain install $env:RUST_TOOLCHAIN
+        rustup toolchain default $env:RUST_TOOLCHAIN
+        rustup target add $env:RUST_TARGET
+        rustup set default-host $env:RUST_TARGET
 
     - name: Install cargo-nextest
       shell: powershell
@@ -213,23 +219,33 @@ jobs:
     - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
 
     - name: build tests
+      env:
+        RUST_TARGET: ${{ matrix.target }}
       run: |
-        cargo nextest run --locked --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --no-run
+        $feat = if ($env:FEATURES) { $env:FEATURES -split '\s+' } else { @() }
+        cargo nextest run --locked --workspace @feat --lib --bins --tests --target $env:RUST_TARGET --no-run
 
     - name: list ignored tests
-      run: |
-        cargo nextest list --locked --workspace ${{ env.FEATURES }} --lib --bins --tests --target ${{ matrix.target }} --run-ignored ignored-only
       env:
         NEXTEST_NO_TESTS: "pass"
+        RUST_TARGET: ${{ matrix.target }}
+      run: |
+        $feat = if ($env:FEATURES) { $env:FEATURES -split '\s+' } else { @() }
+        cargo nextest list --locked --workspace @feat --lib --bins --tests --target $env:RUST_TARGET --run-ignored ignored-only
 
     - name: tests
-      run: |
-        mkdir -p output
-        cargo nextest run --locked --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
       env:
         RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
         NEXTEST_NO_TESTS: "pass"
+        RUST_TARGET: ${{ matrix.target }}
+        RUN_IGNORED: ${{ inputs.flaky && 'all' || 'default' }}
+        MSG_FORMAT: ${{ inputs.flaky && 'libtest-json' || 'human' }}
+        OUT_NAME: ${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}
+      run: |
+        mkdir -p output
+        $feat = if ($env:FEATURES) { $env:FEATURES -split '\s+' } else { @() }
+        cargo nextest run --locked --workspace @feat --lib --bins --tests --profile ci --target $env:RUST_TARGET --run-ignored $env:RUN_IGNORED --no-fail-fast --message-format $env:MSG_FORMAT > "output/$($env:OUT_NAME).json"
 
     - name: upload results
       if: ${{ failure() && inputs.flaky }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,6 +60,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
+        persist-credentials: false
         ref: ${{ inputs.git-ref }}
 
     - name: Install ${{ matrix.rust }} rust
@@ -170,6 +171,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
+        persist-credentials: false
         ref: ${{ inputs.git-ref }}
 
     - name: Install ${{ matrix.rust }}
@@ -256,6 +258,8 @@ jobs:
             runner: [self-hosted, macOS, ARM64]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: nightly

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,6 +26,10 @@ env:
   CRATES_LIST: "netwatch,portmapper"
   IROH_FORCE_STAGING_RELAYS: "1"
 
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   build_and_test_nix:
     timeout-minutes: 30

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,22 +54,22 @@ jobs:
       RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ inputs.git-ref }}
 
     - name: Install ${{ matrix.rust }} rust
-      uses: dtolnay/rust-toolchain@master
+      uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
         toolchain: ${{ matrix.rust }}
 
     - name: Install cargo-nextest
-      uses: taiki-e/install-action@v2
+      uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
       with:
         tool: nextest@0.9.80
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.11
+      uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
     - name: Select features
       run: |
@@ -125,7 +125,7 @@ jobs:
 
     - name: upload results
       if: ${{ failure() && inputs.flaky }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
         path: output
@@ -164,7 +164,7 @@ jobs:
       RUSTC_WRAPPER: "sccache"
     steps:
     - name: Checkout
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         ref: ${{ inputs.git-ref }}
 
@@ -202,9 +202,9 @@ jobs:
         }
 
     - name: Install sccache
-      uses: mozilla-actions/sccache-action@v0.0.11
+      uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
-    - uses: msys2/setup-msys2@v2
+    - uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0
 
     - name: build tests
       run: |
@@ -227,7 +227,7 @@ jobs:
 
     - name: upload results
       if: ${{ failure() && inputs.flaky }}
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: libtest_run_${{ github.run_number }}-${{ github.run_attempt }}-${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
         path: output
@@ -251,8 +251,10 @@ jobs:
             release-arch: aarch64
             runner: [self-hosted, macOS, ARM64]
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: nightly
       - name: cargo check
         run: |
           rm -f Cargo.lock

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,54 @@
+# Static analysis of our own workflows. The tree is clean, so this gates on
+# every finding, not just High.
+name: Workflow Lint
+
+on:
+  pull_request:
+    paths: ['.github/workflows/**', '.github/dependabot.yml', '.pinact.yaml']
+  push:
+    branches: [main]
+    paths: ['.github/workflows/**', '.github/dependabot.yml', '.pinact.yaml']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@7f4eb899022d8fe70b20c4f3de697aa85c309026 # v2.85.11
+        with:
+          tool: zizmor
+      # whole repo, not just workflows/ -- dependabot.yml is audited too
+      - run: zizmor --offline .
+
+  pinact:
+    # Fails if a pinned SHA drifts from its version comment, or is younger
+    # than the cooldown in .pinact.yaml.
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      # Release tarball + checksum instead of pinact-action, which wants
+      # contents:write to push commits. This job only reads.
+      - name: Install pinact
+        env:
+          PINACT_VERSION: "4.1.1"
+        run: |
+          set -euo pipefail
+          base="https://github.com/suzuki-shunsuke/pinact/releases/download/v${PINACT_VERSION}"
+          curl -fsSL -O "$base/pinact_linux_amd64.tar.gz"
+          curl -fsSL -O "$base/pinact_${PINACT_VERSION}_checksums.txt"
+          grep ' pinact_linux_amd64.tar.gz$' "pinact_${PINACT_VERSION}_checksums.txt" | sha256sum -c -
+          tar xzf pinact_linux_amd64.tar.gz pinact
+          install -m755 pinact /usr/local/bin/pinact
+      - run: pinact run --check --verify-comment --verify-min-age
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+version: 3
+
+min_age:
+  value: 7 # days, matches the dependabot cooldown
+
+# No semver tag upstream to verify the version comment against. Forks; revisit
+# rather than leave indefinitely.
+rules:
+  - ignore: true
+    conditions:
+      # fork of nttld/setup-ndk, 1 commit ahead ("allow other hosts").
+      # Upstream the patch and switch to v1.6.0.
+      - expr: |
+          ActionName == "arqu/setup-ndk"
+  - ignore: true
+    conditions:
+      # fork of obi1kenobi/cargo-semver-checks-action; check whether the
+      # baseline feature landed upstream.
+      - expr: |
+          ActionName == "n0-computer/cargo-semver-checks-action"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -16,7 +16,7 @@ args = [
 [tasks.patchbay]
 workspace = false
 command = "cargo"
-args = ["nextest", "run", "-p", "netwatch", "--test", "patchbay", "--profile", "patchbay", "${@}"]
+args = ["nextest", "run", "--locked", "-p", "netwatch", "--test", "patchbay", "--profile", "patchbay", "${@}"]
 
 # Verifies netwatch does not leak unapproved external crate types (notably
 # `netdev`) through its public API. The allowlist lives in

--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,9 @@ expression = "MIT AND ISC AND OpenSSL"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
 [advisories]
+# Yanking is how the 2026-08-20 arrayref attack was staged: yank every version
+# satisfying a range so the malicious upload is the only one left.
+yanked = "deny"
 ignore = [
     "RUSTSEC-2024-0436", # paste unmaintained
 ]


### PR DESCRIPTION
## Description

Same pricinple as https://github.com/n0-computer/noq/pull/788

Uses --locked to ensure we only use deps from the lock file
Adds cooldown period to dependabot
pins actions versions
introduces zizimor and pinact

## Breaking Changes
<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
## Notes & open questions
<!-- Any notes, remarks or open questions you have to make about the PR. -->
## Change checklist
- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.