### PR TITLE
fix(netwatch): ignore RTM_MISS in the BSD route monitor

### DIFF
--- a/netwatch/src/netmon/bsd.rs
+++ b/netwatch/src/netmon/bsd.rs
@@ -172,6 +172,12 @@ pub(super) fn is_interesting_message(msg: &WireMessage) -> bool {
             true
         }
         WireMessage::Route(msg) => {
+            // RTM_MISS is not a route change and can be emitted often on
+            // dual-stack hosts with no IPv6 connectivity.
+            if msg.r#type as libc::c_int == libc::RTM_MISS {
+                return false;
+            }
+
             // Ignore local unicast
             if let Some(addr) = msg.addrs.get(RTAX_DST as usize)
                 && let Some(ip) = addr.ip()


### PR DESCRIPTION
## Description

RTM_MISS reports the fate of a packet, not a routing table change, but
was treated as a topology event and triggered a full interface
enumeration on every occurrence.

On macOS with no working IPv6 route, the kernel broadcasts RTM_MISS
whenever some process attempts an IPv6 connection to every AF_ROUTE
listener, causing repeated unnecessary enumerations that all conclude
nothing changed.

## Breaking Changes

n/a

## Notes & open questions

Replacement of #203 which seems to be stuck on github. Original commit
cherry picked into this branch.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.