### PR TITLE
fix(netwatch): Support wine fully

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,3 +17,9 @@ fail-fast = false
 test-threads = 1
 default-filter = 'binary(patchbay)'
 slow-timeout = { period = "30s", terminate-after = 4 }
+
+[profile.wine]
+# Run all tests even if some fail, so we get full visibility.
+fail-fast = false
+# Run tests sequentially - Wine networking can be flaky with concurrent tests.
+test-threads = 1

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -24,4 +24,4 @@ fail-fast = false
 # Run tests sequentially - Wine networking can be flaky with concurrent tests.
 test-threads = 1
 # These tests are known to fail as they triggger unimplmented stubs, but do not affect iroh.
-default-filter = 'not test(/^netwatch::interfaces::tests::test_(default_route|likely_home_router)$/)'
+default-filter = 'not test(/interfaces::tests::test_(default_route|likely_home_router)/)'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -23,3 +23,5 @@ slow-timeout = { period = "30s", terminate-after = 4 }
 fail-fast = false
 # Run tests sequentially - Wine networking can be flaky with concurrent tests.
 test-threads = 1
+# These tests are known to fail as they triggger unimplmented stubs, but do not affect iroh.
+default-filter = 'not test(/^netwatch::interfaces::tests::test_(default_route|likely_home_router)$/)'

--- a/.github/workflows/wine.yaml
+++ b/.github/workflows/wine.yaml
@@ -22,7 +22,6 @@ permissions:
 jobs:
   wine_test:
     name: Wine Sanity Check
-    needs: pick-runner
     runs-on: [self-hosted, linux, X64]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/wine.yaml
+++ b/.github/workflows/wine.yaml
@@ -20,18 +20,10 @@ permissions:
   contents: read
 
 jobs:
-  pick-runner:
-    uses: "./.github/workflows/pick-runner.yml"
-    with:
-      min_free_runners: 3
-    secrets:
-      RUNNER_READ_TOKEN: ${{ secrets.RUNNER_READ_TOKEN }}
-
   wine_test:
     name: Wine Sanity Check
     needs: pick-runner
-    runs-on: ${{ fromJSON(needs.pick-runner.outputs.overflow_1) }}
-    # runs-on: [self-hosted, linux, X64]
+    runs-on: [self-hosted, linux, X64]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/wine.yaml
+++ b/.github/workflows/wine.yaml
@@ -1,0 +1,77 @@
+name: Wine Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: wine-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: -Dwarnings
+
+# Default to read-only; jobs that need more grant it explicitly.
+permissions:
+  contents: read
+
+jobs:
+  pick-runner:
+    uses: "./.github/workflows/pick-runner.yml"
+    with:
+      min_free_runners: 3
+    secrets:
+      RUNNER_READ_TOKEN: ${{ secrets.RUNNER_READ_TOKEN }}
+
+  wine_test:
+    name: Wine Sanity Check
+    needs: pick-runner
+    runs-on: ${{ fromJSON(needs.pick-runner.outputs.overflow_1) }}
+    # runs-on: [self-hosted, linux, X64]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Wine
+        run: |
+          # Use WineHQ for newer Wine with bcryptprimitives.dll support
+          sudo dpkg --add-architecture i386
+          sudo mkdir -pm755 /etc/apt/keyrings
+          sudo wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
+          sudo wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/$(lsb_release -cs)/winehq-$(lsb_release -cs).sources
+          sudo apt-get update
+          sudo apt-get install -y --install-recommends winehq-stable || sudo apt-get install -y wine64 wine32
+          # Initialize Wine prefix
+          WINEARCH=win64 wineboot --init
+
+      - name: Install Rust + mingw target
+        uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+          targets: x86_64-pc-windows-gnu
+
+      - name: Install mingw-w64
+        run: sudo apt-get install -y mingw-w64
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@82cd3e7658a6f96c86c0234aeeda1748937cb0a1 # v2.85.13
+        with:
+          tool: nextest
+
+      - name: Build tests
+        run: cargo build --locked --target x86_64-pc-windows-gnu --tests
+
+      - name: Run tests under Wine
+        env:
+          CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUNNER: wine
+        run: >
+          cargo nextest run
+          --locked
+          --target x86_64-pc-windows-gnu
+          --profile wine
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1042,6 +1042,33 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "netdev"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "569dfbdd2efd771b24ec9bb57f956e04d4fbfc72f62b2f11961723f9b3f4b020"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "dlopen2",
+ "ipnet",
+ "jni 0.21.1",
+ "libc",
+ "mac-addr",
+ "ndk-context",
+ "netlink-packet-core",
+ "netlink-packet-route 0.31.0",
+ "netlink-sys",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-wlan",
+ "objc2-foundation",
+ "objc2-system-configuration",
+ "once_cell",
+ "plist",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "netdev"
 version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a5f88621a4b468e8ce92626f847cc02462cef3e06d793baa8b1c8617e304b20"
@@ -1140,7 +1167,8 @@ dependencies = [
  "n0-error",
  "n0-future",
  "n0-watcher",
- "netdev",
+ "netdev 0.45.0",
+ "netdev 0.46.1",
  "netlink-packet-core",
  "netlink-packet-route 0.31.0",
  "netlink-proto",
@@ -1306,10 +1334,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-wlan"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
+ "objc2-security-foundation",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "objc2-security"
@@ -1320,6 +1375,16 @@ dependencies = [
  "bitflags",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]

--- a/netwatch/Cargo.toml
+++ b/netwatch/Cargo.toml
@@ -42,8 +42,17 @@ socket2 = { version = "0.6", features = ["all"] }
 tokio = { version = "1", features = ["rt", "net"] }
 
 # netdev is available on all non-embedded, non-wasm platforms
-[target.'cfg(not(any(target_os = "espidf", all(target_family = "wasm", target_os = "unknown"))))'.dependencies]
+# temp older version for windows: https://github.com/shellrow/netdev/pull/186
+[target.'cfg(not(any(target_os = "espidf", all(target_family = "wasm", target_os = "unknown")), target_os = "windows"))'.dependencies]
 netdev = "0.46.1"
+tokio = { version = "1", features = [
+    "fs",
+    "io-std",
+] }
+
+# temp older version of netdev for windows: https://github.com/shellrow/netdev/pull/186
+[target.'cfg(all(not(any(target_os = "espidf", all(target_family = "wasm", target_os = "unknown"))), target_os = "windows"))'.dependencies]
+netdev = "0.45.0"
 tokio = { version = "1", features = [
     "fs",
     "io-std",

--- a/netwatch/Cargo.toml
+++ b/netwatch/Cargo.toml
@@ -43,7 +43,7 @@ tokio = { version = "1", features = ["rt", "net"] }
 
 # netdev is available on all non-embedded, non-wasm platforms
 # temp older version for windows: https://github.com/shellrow/netdev/pull/186
-[target.'cfg(not(any(target_os = "espidf", all(target_family = "wasm", target_os = "unknown")), target_os = "windows"))'.dependencies]
+[target.'cfg(not(any(target_os = "espidf", all(target_family = "wasm", target_os = "unknown"), target_os = "windows")))'.dependencies]
 netdev = "0.46.1"
 tokio = { version = "1", features = [
     "fs",


### PR DESCRIPTION
## Description

This adds support for wine in this crate, and pins netdev to an
earlier version that still works on wine. We want the most recent
version on non-windows platforms however, since there are important
improvements e.g. on macOS.

## Breaking Changes

none

## Notes & open questions

The fix is supposed to be temporary, until
https://github.com/shellrow/netdev/pull/186 is merged.

The added CI uses a nexttest profile for wine. Two tests are known
to fail, but iroh's test suite passes fine without those.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.