### PR TITLE
chore(ci): Move minimal crates check out of flaky test run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,11 @@ jobs:
   tests:
     name: CI Test Suite
     if: "github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'flaky-test')"
-    uses: './.github/workflows/tests.yaml'
+    uses: '$/.github/workflows/tests.yaml'
+
+  min-crates:
+    name: Min Crates
+    uses: "n0-computer/workflows/.github/workflows/minimal-crates.yaml@flub/min-crates"
 
   cross_build:
     name: Cross Build Only

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
 
   min-crates:
     name: Min Crates
-    uses: "n0-computer/workflows/.github/workflows/minimal-crates.yaml@fc6041b3f9ebf3ad00ba1abf70c75b6817a6f6f4" # main
+    uses: "n0-computer/workflows/.github/workflows/minimal-crates.yaml@main"
 
   cross_build:
     name: Cross Build Only

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
 
   min-crates:
     name: Min Crates
-    uses: "n0-computer/workflows/.github/workflows/minimal-crates.yaml@flub/min-crates-take-2"
+    uses: "n0-computer/workflows/.github/workflows/minimal-crates.yaml@75caf4fc38df1b341f70cc462392952300dc16e9" # v1.0.0
 
   cross_build:
     name: Cross Build Only

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
 
   min-crates:
     name: Min Crates
-    uses: "n0-computer/workflows/.github/workflows/minimal-crates.yaml@flub/min-crates"
+    uses: "n0-computer/workflows/.github/workflows/minimal-crates.yaml@fc6041b3f9ebf3ad00ba1abf70c75b6817a6f6f4" # main
 
   cross_build:
     name: Cross Build Only

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
 
   min-crates:
     name: Min Crates
-    uses: "n0-computer/workflows/.github/workflows/minimal-crates.yaml@75caf4fc38df1b341f70cc462392952300dc16e9" # v1.0.0
+    uses: "n0-computer/workflows/.github/workflows/minimal-crates.yaml@4514d123f073733a6d0cd2aed4825d02bd4f6971" # v1.0.0
 
   cross_build:
     name: Cross Build Only

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
 
   min-crates:
     name: Min Crates
-    uses: "n0-computer/workflows/.github/workflows/minimal-crates.yaml@main"
+    uses: "n0-computer/workflows/.github/workflows/minimal-crates.yaml@flub/min-crates-take-2"
 
   cross_build:
     name: Cross Build Only

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -255,39 +255,3 @@ jobs:
         path: output
         retention-days: 1
         compression-level: 0
-  minimal-crates:
-    # Ephemeral only: this job resolves versions the lockfile has never seen
-    # and runs their build scripts.
-    runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        name: [ubuntu-latest, macOS-arm-latest] # TODO: figure out install on windows
-        include:
-          - name: ubuntu-latest
-            os: ubuntu-latest
-            release-os: linux
-            release-arch: amd64
-            runner: ubuntu-latest
-          - name: macOS-arm-latest
-            os: macOS-latest
-            release-os: darwin
-            release-arch: aarch64
-            runner: macos-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
-        with:
-          toolchain: nightly
-      - name: cargo check
-        # No --locked: re-resolving is the point, so -Z min-publish-age guards
-        # the versions the lockfile has never seen.
-        run: |
-          rm -f Cargo.lock
-          cargo +nightly check -Z minimal-versions -Z min-publish-age \
-            --config 'registry.global-min-publish-age="3 days"' \
-            --workspace --all-features --lib --bins

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -49,6 +49,6 @@ jobs:
           grep ' pinact_linux_amd64.tar.gz$' "pinact_${PINACT_VERSION}_checksums.txt" | sha256sum -c -
           tar xzf pinact_linux_amd64.tar.gz pinact
           install -m755 pinact /usr/local/bin/pinact
-      - run: pinact run --check --verify-comment --verify-min-age --branch-to-tag '^main$'
+      - run: pinact run --check --verify-comment --verify-min-age
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -49,6 +49,6 @@ jobs:
           grep ' pinact_linux_amd64.tar.gz$' "pinact_${PINACT_VERSION}_checksums.txt" | sha256sum -c -
           tar xzf pinact_linux_amd64.tar.gz pinact
           install -m755 pinact /usr/local/bin/pinact
-      - run: pinact run --check --verify-comment --verify-min-age
+      - run: pinact run --check --verify-comment --verify-min-age --branch-to-tag '^main$'
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -19,3 +19,7 @@ rules:
       # baseline feature landed upstream.
       - expr: |
           ActionName == "n0-computer/cargo-semver-checks-action"
+  - min_age: 0
+    conditions:
+      - expr: |
+          ActionRepoOwner == "n0-computer"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,9 +130,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,8 +146,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1159,6 +1161,7 @@ dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases",
+ "chrono",
  "ctor",
  "derive_more",
  "ipnet",

--- a/netwatch/Cargo.toml
+++ b/netwatch/Cargo.toml
@@ -73,10 +73,11 @@ netlink-sys = "0.8.7"
 tokio = { version = "1", features = ["process"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
+chorono = "0.4.23"              # Transitive, wmi does not specify min version correctly
+serde = { version = "1", features = ["derive"] }
 wmi = "0.18"
 windows = { version = "0.62.2", features = ["Win32_NetworkManagement_IpHelper", "Win32_Foundation", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock"] }
 windows-result = "0.4"
-serde = { version = "1", features = ["derive"] }
 
 # wasm-in-browser dependencies
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]

--- a/netwatch/Cargo.toml
+++ b/netwatch/Cargo.toml
@@ -73,7 +73,7 @@ netlink-sys = "0.8.7"
 tokio = { version = "1", features = ["process"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-chorono = "0.4.23"              # Transitive, wmi does not specify min version correctly
+chrono = "0.4.23"              # Transitive, wmi does not specify min version correctly
 serde = { version = "1", features = ["derive"] }
 wmi = "0.18"
 windows = { version = "0.62.2", features = ["Win32_NetworkManagement_IpHelper", "Win32_Foundation", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock"] }


### PR DESCRIPTION
## Description

The minimal crates currently are run as part of the daily flaky test
suite. That's a waste of resources. Just as for iroh, move these out
and make them a direct dependency of the main CI job instead.

The minimal creates workflow is identical between this repo and the
iroh one, so start using a re-usable workflow in a separate repo
instead.

## Breaking Changes

none

## Notes & open questions

This currently points at the branch for the workflow, needs to be
moved to main once https://github.com/n0-computer/workflows/pull/2 is
merged.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.