### PR TITLE
chore: Add cargo-make and gh templates like in noq

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,52 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: '[description]'
+projects: ["n0-computer/1"]
+assignees: ''
+type: bug
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**Relevant Logs**
+<!-- Setup `tracing_subscriber` in your application and use the `RUST_LOG = trace` env variable to turn on debug logs. Please see: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/fn.init.html -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**netwatch, portmapper**
+
+Version:
+
+<!-- If possible use cargo tree: -->
+
+```
+[paste output from `cargo tree -i -e features -p netwatch` (or portmapper) here]
+```
+
+<!-- Otherwise, please list the version and/or commit hash. -->
+
+**Platform(s)**
+Desktop<!-- (please complete the following information) -->:
+ - OS: [e.g. iOS]
+ - Version [e.g. 22]
+
+Smartphone<!-- (please complete the following information) -->:
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Version [e.g. 22]
+
+**Additional Context / Screenshots / GIFs**
+<!-- Add any other context about the problem here. -->
+
+**lolwut**
+<!-- You made it to the bottom! Nice, now just prove you're human: -->
+
+- [ ] This issue was created by a human that thought critically about
+      the issue being reported and wrote this as concisely and clearly
+      as they could. Taking full responsibility for the issue being
+      accurate.
+- [ ] This issue isn't slop, and is backed up by evidence.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,24 @@
 ## Description
+
 <!-- A summary of what this pull request achieves and a rough list of changes. -->
-## Breaking Changes
-<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->
+
+## API Changes
+
+<!-- Optional, any API additions, deprecations or breaking changes, including how to migrate older code. -->
+
 ## Notes & open questions
+
 <!-- Any notes, remarks or open questions you have to make about the PR. -->
+
 ## Change checklist
+
 - [ ] Self-review.
 - [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
 - [ ] Tests if relevant.
-- [ ] All breaking changes documented.
+- [ ] All API changes documented.
+- [ ] This PR was created by a human that thought critically about the
+      proposed change and wrote an as clear and concise description as
+      they could.
+- [ ] This PR isn't slop, and is carefully crafted to do have the
+      intented effect.
+- [ ] `cargo make` passes locally.

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,5 +1,30 @@
 # Use cargo-make to run tasks here: https://crates.io/crates/cargo-make
 
+[config]
+skip_core_tasks = true
+default_to_workspace = false
+
+[env]
+CARGO_BUILD_WARNINGS = "deny"
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+# Workspace members to exclude when setting `workspace = true` for a task.
+# Must live at global env (not task-level) so it's read before workspace iteration
+# is generated. Only the `check-external-types` task uses this.
+CARGO_MAKE_WORKSPACE_SKIP_MEMBERS = ["bench", "fuzz", "perf", "docs/book"]
+
+[tasks.default]
+alias = "dev-flow"
+
+[tasks.dev-flow]
+description = "Fast local sub-set of all CI checks"
+dependencies = [
+     "format-check",
+     "check",
+     "clippy",
+     "doc",
+     "test",
+]
+
 [tasks.format]
 workspace = false
 command = "cargo"
@@ -11,6 +36,59 @@ args = [
      "unstable_features=true",
      "--config",
      "imports_granularity=Crate,group_imports=StdExternalCrate,reorder_imports=true,format_code_in_doc_comments=true",
+]
+
+[tasks.format-check]
+workspace = false
+command = "cargo"
+args = [
+     "fmt",
+     "--all",
+     "--check",
+     "--",
+     "--config",
+     "unstable_features=true",
+     "--config",
+     "imports_granularity=Crate,group_imports=StdExternalCrate,reorder_imports=true,format_code_in_doc_comments=true",
+]
+
+[tasks.check]
+description = "Run cargo-check for entire project"
+# Allows us to use CARGO_BUILD_WARNINGS instead of
+# RUSTFLAGS=-Dwarnings which breaks the build cache.
+toolchain = { channel = "stable", min_version = "1.97.0" }
+command = "cargo"
+args = ["check", "--workspace", "--all-features", "--all-targets"]
+
+[tasks.clippy]
+description = "Run cargo-clippy for entire project"
+# Allows us to use CARGO_BUILD_WARNINGS instead of
+# RUSTFLAGS=-Dwarnings which breaks the build cache.
+toolchain = { channel = "stable", min_version = "1.97.0" }
+command = "cargo"
+args = ["clippy", "--workspace", "--all-features", "--all-targets"]
+
+[tasks.doc]
+description = "Check the documentation build"
+# Allows us to use CARGO_BUILD_WARNINGS instead of
+# RUSTDOCFLAGS=-Dwarnings which breaks the build cache.
+toolchain = { channel = "stable", min_version = "1.97.0" }
+command = "cargo"
+args = ["doc", "--workspace", "--all-features", "--no-deps", "--document-private-items"]
+
+[tasks.test]
+description = "Run unit tests"
+command = "cargo"
+args = [
+     "nextest",
+     "run",
+     "--workspace",
+     "--all-features",
+     "--exclude=fuzz",
+     "--lib",
+     "--bins",
+     "--tests",
+     "--no-fail-fast",
 ]
 
 [tasks.patchbay]
@@ -28,17 +106,3 @@ workspace = false
 toolchain = "${TOOLCHAIN:nightly-2026-03-20}"
 command = "cargo"
 args = ["check-external-types", "--manifest-path", "netwatch/Cargo.toml"]
-
-[tasks.format-check]
-workspace = false
-command = "cargo"
-args = [
-     "fmt",
-     "--all",
-     "--check",
-     "--",
-     "--config",
-     "unstable_features=true",
-     "--config",
-     "imports_granularity=Crate,group_imports=StdExternalCrate,reorder_imports=true,format_code_in_doc_comments=true",
-]


### PR DESCRIPTION
## Description

This updates cargo-make so we can use it like in noq. It also updates
the issue and PR templates based on those in noq. This means the PR
template now refers to cargo make as well.

## Breaking Changes

n/a

## Notes & open questions

n/a

## Change checklist
- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.