### PR TITLE
fix(netwatch): discover Windows default routes without WMI

### DIFF
--- a/.github/workflows/windows-route-change.yaml
+++ b/.github/workflows/windows-route-change.yaml
@@ -1,0 +1,52 @@
+name: Windows route changes
+
+on:
+  pull_request:
+  push:
+    branches: [main, fix/windows-default-route-without-wmi]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  route-change:
+    # This test changes system routes. Never run on the shared self-hosted runners.
+    runs-on: windows-2022
+    timeout-minutes: 20
+    env:
+      RUST_BACKTRACE: '1'
+      RUSTFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
+        with:
+          toolchain: stable
+      - name: Build test before changing routes
+        shell: pwsh
+        run: |
+          $messages = cargo test --locked -p netwatch --all-features --test windows_route_change --no-run --message-format=json
+          if ($LASTEXITCODE -ne 0) { throw 'Test compilation failed' }
+          $binary = $messages | ForEach-Object { $_ | ConvertFrom-Json } |
+            Where-Object { $_.reason -eq 'compiler-artifact' -and $_.executable } |
+            Select-Object -ExpandProperty executable
+          if (@($binary).Count -ne 1) { throw 'Expected one test executable' }
+          "NETWATCH_TEST_BINARY=$binary" >> $env:GITHUB_ENV
+      - name: Get Microsoft DevCon
+        shell: pwsh
+        run: |
+          $zip = Join-Path $env:RUNNER_TEMP 'wdk.zip'
+          Invoke-WebRequest 'https://api.nuget.org/v3-flatcontainer/microsoft.windows.wdk.x64/10.0.26100.6584/microsoft.windows.wdk.x64.10.0.26100.6584.nupkg' -OutFile $zip
+          if ((Get-FileHash $zip -Algorithm SHA256).Hash -ne 'c393d03dfb640b5c92f546b32f6770ef68cd3aaf691956e7d66d8e2c28a1b55e') {
+            throw 'WDK package checksum mismatch'
+          }
+          $directory = Join-Path $env:RUNNER_TEMP 'wdk'
+          Expand-Archive $zip $directory
+          $devcon = @(Get-ChildItem $directory -Recurse -Filter devcon.exe | Where-Object { $_.FullName -match '\\x64\\' })
+          if ($devcon.Count -ne 1) { throw 'Expected one x64 DevCon executable' }
+          "NETWATCH_DEVCON=$($devcon[0].FullName)" >> $env:GITHUB_ENV
+      - name: Switch default routes and verify native monitor notifications
+        shell: powershell
+        run: ./scripts/windows-route-change.ps1 -TestBinary $env:NETWATCH_TEST_BINARY

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,10 +146,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1161,7 +1159,6 @@ dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases",
- "chrono",
  "ctor",
  "derive_more",
  "ipnet",
@@ -1181,7 +1178,6 @@ dependencies = [
  "objc2-system-configuration",
  "patchbay",
  "pin-project-lite",
- "serde",
  "socket2",
  "testresult",
  "time",
@@ -1194,7 +1190,6 @@ dependencies = [
  "web-sys",
  "windows",
  "windows-result",
- "wmi",
 ]
 
 [[package]]
@@ -2620,21 +2615,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wmi"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64"
-dependencies = [
- "chrono",
- "futures",
- "log",
- "serde",
- "thiserror 2.0.20",
- "windows",
- "windows-core",
 ]
 
 [[package]]

--- a/netwatch/Cargo.toml
+++ b/netwatch/Cargo.toml
@@ -73,9 +73,6 @@ netlink-sys = "0.8.7"
 tokio = { version = "1", features = ["process"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-chrono = "0.4.23"              # Transitive, wmi does not specify min version correctly
-serde = { version = "1", features = ["derive"] }
-wmi = "0.18"
 windows = { version = "0.62.2", features = ["Win32_NetworkManagement_IpHelper", "Win32_Foundation", "Win32_NetworkManagement_Ndis", "Win32_Networking_WinSock"] }
 windows-result = "0.4"
 

--- a/netwatch/src/interfaces/netdev_impl.rs
+++ b/netwatch/src/interfaces/netdev_impl.rs
@@ -4,8 +4,8 @@
 //! shared by all `netdev`-capable platforms (linux, android, bsd, macos,
 //! windows).
 //!
-//! This is the only module that depends on `netdev`. Everything it produces is
-//! expressed in terms of the types defined in [`crate::interfaces`].
+//! Everything this module produces is expressed in terms of the types defined
+//! in [`crate::interfaces`], keeping `netdev` types out of the public API.
 
 use std::net::IpAddr;
 

--- a/netwatch/src/interfaces/windows.rs
+++ b/netwatch/src/interfaces/windows.rs
@@ -1,49 +1,28 @@
-use std::collections::HashMap;
-
-use n0_error::{e, stack_error};
-use serde::Deserialize;
+use n0_error::stack_error;
 use tracing::warn;
-use wmi::{FilterValue, WMIConnection};
 
 use super::DefaultRouteDetails;
 pub(super) use super::netdev_impl::{get_state, home_router};
 
-/// API Docs: <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/wmiiprouteprov/win32-ip4routetable>
-#[derive(Deserialize, Debug)]
-#[allow(non_camel_case_types, non_snake_case)]
-struct Win32_IP4RouteTable {
-    Name: String,
-}
-
 #[stack_error(derive, add_meta, std_sources, from_sources)]
 #[non_exhaustive]
 pub enum Error {
-    #[allow(dead_code)] // not sure why we have this here?
     #[error("IO")]
     Io { source: std::io::Error },
-    #[error("not route found")]
-    NoRoute {},
-    #[error("WMI")]
-    Wmi { source: wmi::WMIError },
 }
 
 fn get_default_route() -> Result<DefaultRouteDetails, Error> {
-    let wmi_con = WMIConnection::new()?;
-
-    let query: HashMap<_, _> = [("Destination".into(), FilterValue::Str("0.0.0.0"))].into();
-    let route: Win32_IP4RouteTable = wmi_con
-        .filtered_query(&query)?
-        .drain(..)
-        .next()
-        .ok_or_else(|| e!(Error::NoRoute))?;
+    // Use the same interface names as get_state, without requiring WMI/COM
+    // access in sandboxed processes.
+    let route = netdev::get_default_interface().map_err(std::io::Error::other)?;
 
     Ok(DefaultRouteDetails {
-        interface_name: route.Name,
+        interface_name: route.name,
     })
 }
 
 pub async fn default_route() -> Option<DefaultRouteDetails> {
-    // WMI uses COM which can deadlock on a tokio worker thread.
+    // Keep synchronous interface enumeration off the async worker thread.
     match tokio::task::spawn_blocking(get_default_route).await {
         Ok(Ok(route)) => Some(route),
         Ok(Err(err)) => {
@@ -53,6 +32,25 @@ pub async fn default_route() -> Option<DefaultRouteDetails> {
         Err(err) => {
             warn!("default route task panicked: {:#?}", err);
             None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn default_route_names_an_enumerated_interface() {
+        let state = get_state().await;
+        // A disconnected host may have no default route.
+        if let Some(name) = &state.default_route_interface {
+            assert!(
+                state.interfaces.contains_key(name),
+                "default route interface {:?} is missing from {:?}",
+                name,
+                state.interfaces.keys().collect::<Vec<_>>()
+            );
         }
     }
 }

--- a/netwatch/tests/windows_route_change.rs
+++ b/netwatch/tests/windows_route_change.rs
@@ -1,0 +1,89 @@
+//! Run through `scripts/windows-route-change.ps1` on a disposable Windows machine.
+//! The harness provisions adapters and restores routes even if this test fails.
+#![cfg(target_os = "windows")]
+
+use std::{path::PathBuf, process::Command, time::Duration};
+
+use n0_watcher::Watcher;
+use netwatch::{interfaces::State, netmon::Monitor};
+
+fn default_name(state: &State) -> String {
+    let name = state
+        .default_route_interface
+        .as_ref()
+        .expect("a default route must exist in this fixture");
+    assert!(
+        state.interfaces.contains_key(name),
+        "default route must name a key in State::interfaces"
+    );
+    name.to_ascii_lowercase()
+}
+
+#[tokio::test]
+#[ignore = "changes Windows routes; requires the disposable CI harness"]
+async fn windows_default_route_change() {
+    // The flaky-test workflow also runs ignored tests on shared runners.
+    // Provisioning and mutation are only permitted in the dedicated harness.
+    if std::env::var("NETWATCH_ROUTE_TEST").as_deref() != Ok("1") {
+        println!("Skipping: run through scripts/windows-route-change.ps1");
+        return;
+    }
+    let a = std::env::var("NETWATCH_ADAPTER_A_NAME")
+        .unwrap()
+        .to_ascii_lowercase();
+    let b = std::env::var("NETWATCH_ADAPTER_B_NAME")
+        .unwrap()
+        .to_ascii_lowercase();
+    assert_ne!(a, b);
+    let monitor = Monitor::new().await.unwrap();
+    let mut watcher = monitor.interface_state();
+    let mut old = watcher.get();
+    println!("Initial state: {old:#}");
+    assert_eq!(default_name(&old), a);
+
+    // Both adapters and their addresses already exist. Only route metrics change,
+    // so an adapter appearing cannot mask a broken default-route lookup.
+    for (action, expected) in [
+        ("PreferB", &b),
+        ("PreferA", &a),
+        ("PreferB", &b),
+        ("PreferA", &a),
+    ] {
+        let output = tokio::task::spawn_blocking(move || {
+            Command::new("powershell.exe")
+                .args(["-NoProfile", "-NonInteractive", "-File"])
+                .arg(
+                    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                        .join("../scripts/windows-route-change.ps1"),
+                )
+                .args(["-Action", action])
+                .output()
+                .unwrap()
+        })
+        .await
+        .unwrap();
+        println!("{}", String::from_utf8_lossy(&output.stdout));
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        // Do not call Monitor::network_change(): Windows must deliver the event.
+        let new = tokio::time::timeout(Duration::from_secs(20), async {
+            loop {
+                let state = watcher.updated().await.unwrap();
+                println!("Observed state: {state:#}");
+                if &default_name(&state) == expected {
+                    break state;
+                }
+            }
+        })
+        .await
+        .expect("Windows route change did not reach the monitor within 20 seconds");
+        assert_ne!(new.default_route_interface, old.default_route_interface);
+        assert!(new.is_major_change(&old));
+        assert_eq!(&default_name(&State::new().await), expected);
+        old = new;
+    }
+}

--- a/scripts/windows-route-change.ps1
+++ b/scripts/windows-route-change.ps1
@@ -38,7 +38,8 @@ if (-not ([Security.Principal.WindowsPrincipal]$identity).IsInRole([Security.Pri
     throw 'Administrator privileges are required'
 }
 
-$originalRoutes = @(Get-NetRoute -AddressFamily IPv4 -DestinationPrefix '0.0.0.0/0')
+$originalRoutes = @(Get-NetRoute -AddressFamily IPv4 -DestinationPrefix '0.0.0.0/0' |
+    Select-Object InterfaceIndex, DestinationPrefix, NextHop, RouteMetric, InterfaceMetric)
 if ($originalRoutes.Count -eq 0) { throw 'Runner has no IPv4 default route' }
 $uplink = $originalRoutes | Sort-Object { $_.RouteMetric + $_.InterfaceMetric } | Select-Object -First 1
 $preservedRoutes = [System.Collections.Generic.List[object]]::new()
@@ -54,7 +55,10 @@ try {
             -NextHop $uplink.NextHop -RouteMetric 1 -PolicyStore ActiveStore))
     }
     # Keep the original default routes as fallbacks, saving their metrics above.
-    foreach ($route in $originalRoutes) { $route | Set-NetRoute -RouteMetric 5000 -Confirm:$false }
+    foreach ($route in $originalRoutes) {
+        Get-NetRoute -InterfaceIndex $route.InterfaceIndex -DestinationPrefix $route.DestinationPrefix -NextHop $route.NextHop |
+            Set-NetRoute -RouteMetric 5000 -Confirm:$false
+    }
 
     foreach ($slot in @('A', 'B')) {
         $before = @(Get-NetAdapter -IncludeHidden | Select-Object -ExpandProperty InterfaceGuid)
@@ -69,6 +73,11 @@ try {
         if (-not $adapter) { throw 'Virtual Ethernet adapter did not appear' }
         $devices.Add($adapter.PnPDeviceID)
         $adapter | Rename-NetAdapter -NewName "netwatch-test-$slot"
+    }
+    # DevCon updates every device with the same hardware ID, which can reset the
+    # first adapter when installing the second. Configure only after both exist.
+    foreach ($slot in @('A', 'B')) {
+        $adapter = Get-NetAdapter -Name "netwatch-test-$slot"
         $index = $adapter.InterfaceIndex
         Set-Item "Env:NETWATCH_ADAPTER_$slot" $index
         Set-Item "Env:NETWATCH_ADAPTER_${slot}_NAME" ([guid]$adapter.InterfaceGuid).ToString('B')
@@ -89,6 +98,8 @@ try {
     Get-NetAdapter | Format-Table Name, InterfaceIndex, Status | Out-Host
     $env:NETWATCH_ROUTE_TEST = '1'
     $process = Start-Process -FilePath $TestBinary -ArgumentList @('--ignored', '--exact', 'windows_default_route_change', '--nocapture') -NoNewWindow -PassThru
+    # Retain the handle so Windows PowerShell can read ExitCode after exit.
+    $null = $process.Handle
     if (-not $process.WaitForExit(120000)) { throw 'Route test exceeded its two-minute deadline' }
     if ($process.ExitCode -ne 0) { throw "Route test failed with exit code $($process.ExitCode)" }
 } finally {

--- a/scripts/windows-route-change.ps1
+++ b/scripts/windows-route-change.ps1
@@ -17,6 +17,12 @@ function Assert-Default([int]$Expected) {
         ($routes[1].RouteMetric + $routes[1].InterfaceMetric)) {
         throw "Windows routing table does not uniquely prefer interface $Expected"
     }
+    # Also check Windows source-address selection, independently of netdev.
+    $selected = @(Find-NetRoute -RemoteIPAddress '10.254.254.254')
+    $selected | Format-List | Out-Host
+    if (@($selected | Where-Object { $_.InterfaceIndex -ne $Expected }).Count -ne 0) {
+        throw "Windows source-address selection does not use interface $Expected"
+    }
 }
 
 if ($Action -ne 'Run') {
@@ -84,6 +90,11 @@ try {
         Set-NetIPInterface -InterfaceIndex $index -AddressFamily IPv4 -Dhcp Disabled -AutomaticMetric Disabled -InterfaceMetric 1
         $subnet = if ($slot -eq 'A') { '198.18.0' } else { '198.19.0' }
         New-NetIPAddress -InterfaceIndex $index -IPAddress "$subnet.2" -PrefixLength 24 | Out-Null
+        # netdev resolves gateway MAC addresses with SendARP. Supply a permanent
+        # neighbor for these synthetic gateways to avoid ARP timeouts and Windows
+        # treating the test route as unreachable. No Internet service is simulated.
+        $mac = if ($slot -eq 'A') { '02-00-00-00-00-0A' } else { '02-00-00-00-00-0B' }
+        New-NetNeighbor -InterfaceIndex $index -IPAddress "$subnet.1" -LinkLayerAddress $mac -State Permanent | Out-Null
         $metric = if ($slot -eq 'A') { 10 } else { 100 }
         New-NetRoute -InterfaceIndex $index -DestinationPrefix '0.0.0.0/0' -NextHop "$subnet.1" `
             -RouteMetric $metric -PolicyStore ActiveStore | Out-Null

--- a/scripts/windows-route-change.ps1
+++ b/scripts/windows-route-change.ps1
@@ -1,0 +1,108 @@
+# Run only on disposable machines: temporarily changes system-wide IPv4 routes.
+# Requires elevation and DevCon from Microsoft's WDK (NETWATCH_DEVCON).
+[CmdletBinding()]
+param(
+    [ValidateSet('Run', 'PreferA', 'PreferB')][string]$Action = 'Run',
+    [string]$TestBinary
+)
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Assert-Default([int]$Expected) {
+    $routes = @(Get-NetRoute -AddressFamily IPv4 -DestinationPrefix '0.0.0.0/0' |
+        Sort-Object { $_.RouteMetric + $_.InterfaceMetric })
+    $routes | Format-Table InterfaceIndex, DestinationPrefix, NextHop, RouteMetric, InterfaceMetric | Out-Host
+    if ($routes.Count -lt 2 -or $routes[0].InterfaceIndex -ne $Expected -or
+        ($routes[0].RouteMetric + $routes[0].InterfaceMetric) -eq
+        ($routes[1].RouteMetric + $routes[1].InterfaceMetric)) {
+        throw "Windows routing table does not uniquely prefer interface $Expected"
+    }
+}
+
+if ($Action -ne 'Run') {
+    if ($env:NETWATCH_ROUTE_TEST -ne '1') { throw 'Run through the test harness' }
+    # B stays at 100; moving A between 10 and 200 changes the winner in one operation.
+    $metric = if ($Action -eq 'PreferA') { 10 } else { 200 }
+    Get-NetRoute -InterfaceIndex $env:NETWATCH_ADAPTER_A -DestinationPrefix '0.0.0.0/0' |
+        Set-NetRoute -RouteMetric $metric -Confirm:$false
+    $expected = if ($Action -eq 'PreferA') { $env:NETWATCH_ADAPTER_A } else { $env:NETWATCH_ADAPTER_B }
+    Assert-Default $expected
+    exit 0
+}
+
+if (-not $TestBinary -or -not (Test-Path $TestBinary)) { throw 'Supply a compiled test executable' }
+$devcon = $env:NETWATCH_DEVCON
+if (-not $devcon -or -not (Test-Path $devcon)) { throw 'Set NETWATCH_DEVCON to the WDK devcon.exe' }
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not ([Security.Principal.WindowsPrincipal]$identity).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw 'Administrator privileges are required'
+}
+
+$originalRoutes = @(Get-NetRoute -AddressFamily IPv4 -DestinationPrefix '0.0.0.0/0')
+if ($originalRoutes.Count -eq 0) { throw 'Runner has no IPv4 default route' }
+$uplink = $originalRoutes | Sort-Object { $_.RouteMetric + $_.InterfaceMetric } | Select-Object -First 1
+$preservedRoutes = [System.Collections.Generic.List[object]]::new()
+$devices = [System.Collections.Generic.List[string]]::new()
+$process = $null
+try {
+    # Preserve runner Internet traffic while allowing 10/8 to follow the real
+    # default route. netdev 0.45 probes 10.254.254.254 without sending packets.
+    # These are more-specific routes, not a special route to netdev's probe.
+    foreach ($prefix in @('0.0.0.0/5', '8.0.0.0/7', '11.0.0.0/8', '12.0.0.0/6',
+                          '16.0.0.0/4', '32.0.0.0/3', '64.0.0.0/2', '128.0.0.0/1')) {
+        $preservedRoutes.Add((New-NetRoute -InterfaceIndex $uplink.InterfaceIndex -DestinationPrefix $prefix `
+            -NextHop $uplink.NextHop -RouteMetric 1 -PolicyStore ActiveStore))
+    }
+    # Keep the original default routes as fallbacks, saving their metrics above.
+    foreach ($route in $originalRoutes) { $route | Set-NetRoute -RouteMetric 5000 -Confirm:$false }
+
+    foreach ($slot in @('A', 'B')) {
+        $before = @(Get-NetAdapter -IncludeHidden | Select-Object -ExpandProperty InterfaceGuid)
+        & $devcon install "$env:SystemRoot\inf\netloop.inf" '*MSLOOP'
+        if ($LASTEXITCODE -ne 0) { throw "DevCon install failed or requires reboot: $LASTEXITCODE" }
+        $adapter = $null
+        for ($attempt = 0; $attempt -lt 30; $attempt++) {
+            $new = @(Get-NetAdapter -IncludeHidden | Where-Object { $_.InterfaceGuid -notin $before })
+            if ($new.Count -eq 1) { $adapter = $new[0]; break }
+            Start-Sleep -Seconds 1
+        }
+        if (-not $adapter) { throw 'Virtual Ethernet adapter did not appear' }
+        $devices.Add($adapter.PnPDeviceID)
+        $adapter | Rename-NetAdapter -NewName "netwatch-test-$slot"
+        $index = $adapter.InterfaceIndex
+        Set-Item "Env:NETWATCH_ADAPTER_$slot" $index
+        Set-Item "Env:NETWATCH_ADAPTER_${slot}_NAME" ([guid]$adapter.InterfaceGuid).ToString('B')
+        Set-NetIPInterface -InterfaceIndex $index -AddressFamily IPv4 -Dhcp Disabled -AutomaticMetric Disabled -InterfaceMetric 1
+        $subnet = if ($slot -eq 'A') { '198.18.0' } else { '198.19.0' }
+        New-NetIPAddress -InterfaceIndex $index -IPAddress "$subnet.2" -PrefixLength 24 | Out-Null
+        $metric = if ($slot -eq 'A') { 10 } else { 100 }
+        New-NetRoute -InterfaceIndex $index -DestinationPrefix '0.0.0.0/0' -NextHop "$subnet.1" `
+            -RouteMetric $metric -PolicyStore ActiveStore | Out-Null
+        for ($attempt = 0; $attempt -lt 30; $attempt++) {
+            $address = Get-NetIPAddress -InterfaceIndex $index -AddressFamily IPv4 -IPAddress "$subnet.2"
+            if ($address.AddressState -eq 'Preferred') { break }
+            Start-Sleep -Seconds 1
+        }
+        if ($address.AddressState -ne 'Preferred') { throw 'Virtual adapter address did not become usable' }
+    }
+    Assert-Default $env:NETWATCH_ADAPTER_A
+    Get-NetAdapter | Format-Table Name, InterfaceIndex, Status | Out-Host
+    $env:NETWATCH_ROUTE_TEST = '1'
+    $process = Start-Process -FilePath $TestBinary -ArgumentList @('--ignored', '--exact', 'windows_default_route_change', '--nocapture') -NoNewWindow -PassThru
+    if (-not $process.WaitForExit(120000)) { throw 'Route test exceeded its two-minute deadline' }
+    if ($process.ExitCode -ne 0) { throw "Route test failed with exit code $($process.ExitCode)" }
+} finally {
+    if ($process -and -not $process.HasExited) { $process.Kill(); $process.WaitForExit() }
+    # Restore connectivity first, including after assertion failures or timeout.
+    foreach ($device in $devices) {
+        & $devcon remove "@$device"
+        if ($LASTEXITCODE -ne 0) { Write-Warning "Could not remove test device $device" }
+    }
+    foreach ($route in $originalRoutes) {
+        Get-NetRoute -InterfaceIndex $route.InterfaceIndex -DestinationPrefix $route.DestinationPrefix -NextHop $route.NextHop |
+            Set-NetRoute -RouteMetric $route.RouteMetric -Confirm:$false
+    }
+    foreach ($route in $preservedRoutes) { $route | Remove-NetRoute -Confirm:$false }
+    Remove-Item Env:NETWATCH_ROUTE_TEST -ErrorAction SilentlyContinue
+    Get-NetRoute -AddressFamily IPv4 -DestinationPrefix '0.0.0.0/0' | Format-Table | Out-Host
+}


### PR DESCRIPTION
## Description

Windows default-route discovery currently creates a WMI connection, which requires COM access. In Factorseal's restricted Windows network helper, that path terminated the process with delay-load exception `0xc06d007e` during network startup.

Use the existing `netdev::get_default_interface()` lookup instead. This avoids WMI and returns an interface name from the same source as `get_state()`, matching the documented requirement that `State::default_route_interface` be a key in `State::interfaces`. Synchronous discovery stays on `spawn_blocking`, and lookup failures still produce a warning and `None`.

Remove the WMI dependency and its now-unused Windows-only `chrono` and `serde` declarations. Add a Windows test checking the route-name/map-key contract when a default route is available.

## Breaking Changes

None. No public API changes.

## Notes & open questions

Validation:

- Upstream formatting configuration passes.
- `cargo test --locked -p netwatch --all-features --lib --test smoke`: 17 library tests and one smoke test pass on Linux.
- `cargo xwin clippy --locked --target x86_64-pc-windows-msvc -p netwatch --all-features --all-targets -- -D warnings` passes, including compilation of the new Windows test.
- The same route-lookup change passes [Factorseal's native Windows acceptance](https://github.com/cachix/factorseal/actions/runs/34243843247/job/102120604280), including restricted-helper startup, restart, concurrent views, and three-device delivery through a sealed courier after the sender exits. The helper retains its LPAC token, creation-time mitigations, and job restrictions.

The new upstream Windows test has been cross-compiled locally; its native execution is left to upstream CI. Factorseal's native results exercise the downstream integration, not that new test.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the style guide, where relevant.
- [x] Tests where relevant; validation and native-execution limits listed above.
- [x] All breaking changes documented (none).
